### PR TITLE
use provider scaffolds api

### DIFF
--- a/pkg/api/scaffolds.go
+++ b/pkg/api/scaffolds.go
@@ -1,0 +1,38 @@
+package api
+
+var TfProvidersQuery = `
+	query {
+		terraformProviders
+	}
+`
+
+var TfProviderQuery = `
+	query Provider($name: Provider!) {
+		terraformProvider(name: $name) {
+			name
+			content
+		}
+	}
+`
+
+func (client *Client) GetTfProviders() ([]string, error) {
+	var resp struct {
+		TerraformProviders []string
+	}
+	req := client.Build(TfProvidersQuery)
+	err := client.Run(req, &resp)
+	return resp.TerraformProviders, err
+}
+
+func (client *Client) GetTfProviderScaffold(name string) (string, error) {
+	var resp struct {
+		TerraformProvider struct {
+			Name    string
+			Content string
+		}
+	}
+	req := client.Build(TfProviderQuery)
+	req.Var("name", name)
+	err := client.Run(req, &resp)
+	return resp.TerraformProvider.Content, err
+}

--- a/pkg/provider/aws.go
+++ b/pkg/provider/aws.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"runtime"
 
-	"k8s.io/api/core/v1"
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -15,7 +15,7 @@ import (
 	"github.com/pluralsh/plural/pkg/manifest"
 	"github.com/pluralsh/plural/pkg/template"
 	"github.com/pluralsh/plural/pkg/utils"
-	"github.com/AlecAivazis/survey/v2"
+	v1 "k8s.io/api/core/v1"
 )
 
 type AWSProvider struct {
@@ -28,14 +28,14 @@ type AWSProvider struct {
 
 var awsSurvey = []*survey.Question{
 	{
-			Name:     "cluster",
-			Prompt:   &survey.Input{Message: "Enter the name of your cluster:"},
-			Validate: utils.ValidateAlphaNumeric,
+		Name:     "cluster",
+		Prompt:   &survey.Input{Message: "Enter the name of your cluster:"},
+		Validate: utils.ValidateAlphaNumeric,
 	},
 	{
-			Name: "region",
-			Prompt: &survey.Input{Message: "What region will you deploy to?", Default: "us-east-2"},
-			Validate: survey.Required,
+		Name:     "region",
+		Prompt:   &survey.Input{Message: "What region will you deploy to?", Default: "us-east-2"},
+		Validate: survey.Required,
 	},
 }
 
@@ -69,7 +69,7 @@ func mkAWS(conf config.Config) (*AWSProvider, error) {
 		return nil, err
 	}
 
-	provider.bucket = projectManifest.Bucket 
+	provider.bucket = projectManifest.Bucket
 	return provider, nil
 }
 
@@ -106,7 +106,11 @@ func (aws *AWSProvider) CreateBackend(prefix string, ctx map[string]interface{})
 	if _, ok := ctx["Cluster"]; !ok {
 		ctx["Cluster"] = fmt.Sprintf("\"%s\"", aws.Cluster())
 	}
-	return template.RenderString(awsBackendTemplate, ctx)
+	scaffold, err := GetProviderScaffold("AWS")
+	if err != nil {
+		return "", err
+	}
+	return template.RenderString(scaffold, ctx)
 }
 
 func (aws *AWSProvider) KubeConfig() error {

--- a/pkg/provider/constants.go
+++ b/pkg/provider/constants.go
@@ -1,4 +1,4 @@
-package provider
+package provider // TODO: Deprecate this file
 
 const (
 	GCP     = "google"

--- a/pkg/provider/equinix.go
+++ b/pkg/provider/equinix.go
@@ -124,8 +124,11 @@ func (equinix *EQUINIXProvider) CreateBackend(prefix string, ctx map[string]inte
 
 	utils.WriteFile(filepath.Join(equinix.Bucket(), ".gitignore"), []byte("!/**"))
 	utils.WriteFile(filepath.Join(equinix.Bucket(), ".gitattributes"), []byte("/** filter=plural-crypt diff=plural-crypt\n.gitattributes !filter !diff"))
-
-	return template.RenderString(equinixBackendTemplate, ctx)
+	scaffold, err := GetProviderScaffold("EQUINIX")
+	if err != nil {
+		return "", err
+	}
+	return template.RenderString(scaffold, ctx)
 }
 
 func (equinix *EQUINIXProvider) KubeConfig() error {

--- a/pkg/provider/gcp.go
+++ b/pkg/provider/gcp.go
@@ -10,15 +10,14 @@ import (
 	"strings"
 
 	"github.com/mholt/archiver/v3"
+	v1 "k8s.io/api/core/v1"
 
 	"cloud.google.com/go/storage"
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/pluralsh/plural/pkg/config"
 	"github.com/pluralsh/plural/pkg/manifest"
 	"github.com/pluralsh/plural/pkg/template"
 	"github.com/pluralsh/plural/pkg/utils"
-	"github.com/AlecAivazis/survey/v2"
-
-	"k8s.io/api/core/v1"
 
 	compute "cloud.google.com/go/compute/apiv1"
 	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
@@ -35,14 +34,14 @@ type GCPProvider struct {
 
 var gcpSurvey = []*survey.Question{
 	{
-			Name:     "cluster",
-			Prompt:   &survey.Input{Message: "Enter the name of your cluster"},
-			Validate: utils.ValidateAlphaNumeric,
+		Name:     "cluster",
+		Prompt:   &survey.Input{Message: "Enter the name of your cluster"},
+		Validate: utils.ValidateAlphaNumeric,
 	},
 	{
-			Name: "project",
-			Prompt: &survey.Input{Message: "Enter the name of its gcp project"},
-			Validate: utils.ValidateAlphaNumeric,
+		Name:     "project",
+		Prompt:   &survey.Input{Message: "Enter the name of its gcp project"},
+		Validate: utils.ValidateAlphaNumeric,
 	},
 }
 
@@ -124,7 +123,11 @@ func (gcp *GCPProvider) CreateBackend(prefix string, ctx map[string]interface{})
 	} else {
 		ctx["Cluster"] = fmt.Sprintf(`"%s"`, gcp.Cluster())
 	}
-	return template.RenderString(gcpBackendTemplate, ctx)
+	scaffold, err := GetProviderScaffold("GCP")
+	if err != nil {
+		return "", err
+	}
+	return template.RenderString(scaffold, ctx)
 }
 
 func (gcp *GCPProvider) mkBucket(name string) error {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -33,7 +33,7 @@ type Providers struct {
 var providers = Providers{}
 
 func Bootstrap(manifestPath string, force bool) (Provider, error) {
-	GetAvailableProviders()
+	getAvailableProviders()
 	if utils.Exists(manifestPath) {
 		man, err := manifest.Read(manifestPath)
 		if err != nil {
@@ -62,7 +62,7 @@ func GetProviderScaffold(provider string) (string, error) {
 	return providers.Scaffolds[provider], nil
 }
 
-func GetAvailableProviders() error {
+func getAvailableProviders() error {
 	if providers.AvailableProviders == nil {
 		client := api.NewClient()
 		available, err := client.GetTfProviders()

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -66,6 +66,12 @@ func GetAvailableProviders() error {
 	if providers.AvailableProviders == nil {
 		client := api.NewClient()
 		available, err := client.GetTfProviders()
+		for i := range available {
+			if available[i] == "GCP" {
+				available[i] = "google"
+			}
+			available[i] = strings.ToLower(available[i])
+		}
 		if err != nil {
 			return err
 		}
@@ -112,16 +118,14 @@ func Select(force bool) (Provider, error) {
 }
 
 func FromManifest(man *manifest.Manifest) (Provider, error) {
-	switch strings.ToUpper(man.Provider) {
-	case "GCP":
+	switch man.Provider {
+	case GCP:
 		return gcpFromManifest(man)
-	case "GOOGLE": // for backward compatibility
-		return gcpFromManifest(man)
-	case "AWS":
+	case AWS:
 		return awsFromManifest(man)
-	case "AZURE":
+	case AZURE:
 		return azureFromManifest(man)
-	case "EQUINIX":
+	case EQUINIX:
 		return equinixFromManifest(man)
 	default:
 		return nil, fmt.Errorf("Invalid provider name: %s", man.Provider)
@@ -130,16 +134,14 @@ func FromManifest(man *manifest.Manifest) (Provider, error) {
 
 func New(provider string) (Provider, error) {
 	conf := config.Read()
-	switch strings.ToUpper(provider) {
-	case "GCP":
+	switch provider {
+	case GCP:
 		return mkGCP(conf)
-	case "GOOGLE": // for backward compatibility
-		return mkGCP(conf)
-	case "AWS":
+	case AWS:
 		return mkAWS(conf)
-	case "AZURE":
+	case AZURE:
 		return mkAzure(conf)
-	case "EQUINIX":
+	case EQUINIX:
 		return mkEquinix(conf)
 	default:
 		return nil, fmt.Errorf("Invalid provider name: %s", provider)


### PR DESCRIPTION
## Summary
This PR utilizes the new Plural gql API's to retrieve available TF providers and their base scaffold code.
Once retrieved, the list of available providers and scaffolds are cached in each execution of CLI command.
Note that now the list providers is capitalized, and the "google" provider is now called "gcp"
closes #167

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.