### PR TITLE
GCP allow user to set Region

### DIFF
--- a/pkg/provider/constants.go
+++ b/pkg/provider/constants.go
@@ -71,15 +71,9 @@ const gcpBackendTemplate = `terraform {
   }
 }
 
-locals {
-  gcp_location  = {{ .Values.Location | quote }}
-  gcp_location_parts = split("-", local.gcp_location)
-  gcp_region         = "${local.gcp_location_parts[0]}-${local.gcp_location_parts[1]}"
-}
-
 provider "google" {
   project = {{ .Values.Project | quote }}
-  region  = local.gcp_region
+  region  = {{ .Values.Region | quote }}
 }
 
 data "google_client_config" "current" {}
@@ -93,7 +87,7 @@ provider "kubernetes" {
 {{ else }}
 data "google_container_cluster" "cluster" {
   name = {{ .Values.Cluster }}
-  location = local.gcp_region
+  location = {{ .Values.Region | quote }}
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
This change allows users to configure the GCP region in which they would like to deploy their cluster, bringing it to feature parity with AWS and Azure. It also moves away from using a Zone instead of the Region, since the Zone level setting doesn't seem to be used anywhere and is inconsistent with the other providers on Plural.

This change will also require changes to the CLI template (see ...).


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.