### PR TITLE
CLI Usability Improvements

### DIFF
--- a/cmd/plural/bundle.go
+++ b/cmd/plural/bundle.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pluralsh/plural/pkg/api"
 	"github.com/pluralsh/plural/pkg/bundle"
 	"github.com/pluralsh/plural/pkg/manifest"
+	"github.com/pluralsh/plural/pkg/utils"
 	"github.com/urfave/cli"
 	"os"
 	"strings"
@@ -22,6 +23,12 @@ func bundleCommands() []cli.Command {
 			Name:      "install",
 			Usage:     "installs a bundle and writes the configuration to this installation's context",
 			ArgsUsage: "[repo] [name]",
+			Flags:     []cli.Flag{
+				cli.BoolFlag{
+					Name: "refresh",
+					Usage: "re-enter the configuration for this bundle",
+				},
+			},
 			Action:    requireArgs(bundleInstall, []string{"repo", "bundle-name"}),
 		},
 	}
@@ -49,7 +56,9 @@ func bundleList(c *cli.Context) error {
 	return nil
 }
 
-func bundleInstall(c *cli.Context) error {
+func bundleInstall(c *cli.Context) (err error) {
 	args := c.Args()
-	return bundle.Install(args.Get(0), args.Get(1))
+	err = bundle.Install(args.Get(0), args.Get(1), c.Bool("refresh"))
+	utils.Note("To edit the configuration you've just entered, edit the context.yaml file at the root of your repo, or run with the --refresh flag\n")
+	return
 }

--- a/pkg/bundle/installer.go
+++ b/pkg/bundle/installer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pluralsh/plural/pkg/bundle/tests"
 )
 
-func Install(repo, name string) error {
+func Install(repo, name string, refresh bool) error {
 	client := api.NewClient()
 	recipe, err := client.GetRecipe(repo, name)
 	if err != nil {
@@ -43,12 +43,12 @@ func Install(repo, name string) error {
 				continue
 			}
 
-			if _, ok := ctx[configItem.Name]; ok {
+			if _, ok := ctx[configItem.Name]; ok && !refresh {
 				continue
 			}
 
 			seen[configItem.Name] = true
-			if err := configure(ctx, configItem); err != nil {
+			if err := configure(ctx, configItem, context, section); err != nil {
 				context.Configuration[section.Repository.Name] = ctx
 				context.Write(path)
 				return err

--- a/pkg/manifest/context.go
+++ b/pkg/manifest/context.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"fmt"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"path/filepath"
@@ -98,6 +99,18 @@ func (c *Context) Write(path string) error {
 	}
 
 	return ioutil.WriteFile(path, io, 0644)
+}
+
+func (c *Context) ContainsString(str, msg, ignoreRepo, ignoreKey string) error {
+	for r, section := range c.Configuration {
+		for k, val := range section {
+			if v, ok := val.(string); ok && v == str && (r != ignoreRepo || k != ignoreKey) {
+				return fmt.Errorf(msg)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (smtp *SMTP) GetServer() string {


### PR DESCRIPTION
## Summary
Solves a few things we've noticed with users of our CLI:

* bundle install now provides a notice of where you can edit configuration in the future
* add `--refresh` option to bundle install to re-edit configuration as well
* provide global validation of bucket uniqueness in configuration

## Test Plan
Locally test affected commands

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

Closes #34 #32 