### PR TITLE
Add Reset Installations Support

### DIFF
--- a/cmd/plural/deploy.go
+++ b/cmd/plural/deploy.go
@@ -402,6 +402,7 @@ func destroy(c *cli.Context) error {
 		return git.Sync(repoRoot, commit, c.Bool("force"))
 	}
 
+	utils.Note("To remove your installations in app.plural.sh as well, you can run `plural repos reset`")
 	return nil
 }
 

--- a/cmd/plural/repos.go
+++ b/cmd/plural/repos.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"fmt"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pluralsh/plural/pkg/api"
 	"github.com/urfave/cli"
@@ -14,6 +15,11 @@ func reposCommands() []cli.Command {
 			Usage:     "unlocks installations in a repo that have breaking changes",
 			ArgsUsage: "REPO",
 			Action:    handleUnlockRepo,
+		},
+		{
+			Name:      "reset",
+			Usage:     "eliminates your current plural installation set, to change cloud provider or eject from plural",
+			Action:    handleResetInstallations,
 		},
 		{
 			Name:      "list",
@@ -49,5 +55,17 @@ func handleListRepositories(c *cli.Context) error {
 	}
 
 	table.Render()
+	return nil
+}
+
+func handleResetInstallations(c *cli.Context) error {
+	client := api.NewClient()
+	count, err := client.ResetInstallations()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Deleted %d installations in app.plural.sh\n", count)
+	fmt.Println("(you can recreate these at any time and any running infrastructure is not affected, plural will simply no longer deliver upgrades)")
 	return nil
 }

--- a/pkg/api/installations.go
+++ b/pkg/api/installations.go
@@ -47,6 +47,12 @@ const oidcProviderMut = `
 	}
 `
 
+const resetInstallationsMut = `
+	mutation {
+		resetInstallations
+	}
+`
+
 func (client *Client) GetInstallation(name string) (inst *Installation, err error) {
 	var resp struct {
 		Installation *Installation
@@ -90,4 +96,14 @@ func (client *Client) OIDCProvider(id string, attributes *OidcProviderAttributes
 	req.Var("id", id)
 	req.Var("attributes", attributes)
 	return client.Run(req, &resp)
+}
+
+func (client *Client) ResetInstallations() (int, error) {
+	var resp struct {
+		ResetInstallations int
+	}
+
+	req := client.Build(resetInstallationsMut)
+	err := client.Run(req, &resp)
+	return resp.ResetInstallations, err
 }

--- a/pkg/application/waiter.go
+++ b/pkg/application/waiter.go
@@ -11,6 +11,10 @@ import (
 	tm "github.com/buger/goterm"
 )
 
+const (
+	waitTime = 5 * 60 * time.Second
+)
+
 func Waiter(kubeConf *rest.Config, repo string, appFunc func(app *v1beta1.Application) (bool, error), timeout func() error) error {
 	conf := config.Read()
 	ctx := context.Background()
@@ -48,7 +52,7 @@ func Waiter(kubeConf *rest.Config, repo string, appFunc func(app *v1beta1.Applic
 			if stop, err := appFunc(app); stop || err != nil {
 				return err
 			}
-		case <-time.After(60 * time.Second):
+		case <-time.After(waitTime):
 			if err := timeout(); err != nil {
 				return err
 			}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -133,7 +133,7 @@ func (man *ProjectManifest) ConfigureNetwork() error {
 	
 	subdomain := utils.UntilInputValid(
 		func() (string, error) {
-			return utils.ReadLine(fmt.Sprintf("\nWhat do you want to use as your subdomain%s: ", modifier))
+			return utils.ReadLine(fmt.Sprintf("\nWhat do you want to use as your domain%s: ", modifier))
 		},
 		func(val string) error {
 			if err := utils.ValidateDns(val); err != nil {
@@ -146,7 +146,9 @@ func (man *ProjectManifest) ConfigureNetwork() error {
 
 			if pluralDns {
 				client := api.NewClient()
-				return client.CreateDomain(val)
+				if err := client.CreateDomain(val); err != nil {
+					return fmt.Errorf("Domain %s is taken or your user doesn't have sufficient permissions to create domains", val)
+				}
 			}
 
 			return nil


### PR DESCRIPTION
## Summary
We'll want this when migrating users off kind demos, as it'll wipe existing installs and reset their provider pin.

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.