### PR TITLE
Support multiple redirect uris in recipe oidc

### DIFF
--- a/pkg/api/models.go
+++ b/pkg/api/models.go
@@ -189,10 +189,11 @@ type TestArgument struct {
 }
 
 type OIDCSettings struct {
-	DomainKey  string `yaml:"domainKey"`
-	UriFormat  string `yaml:"uriFormat"`
-	AuthMethod string `yaml:"authMethod"`
-	Subdomain  bool   `yaml:"subdomain"`
+	DomainKey  string   `yaml:"domainKey"`
+	UriFormat  string   `yaml:"uriFormat"`
+	UriFormats []string `yaml:"uriFormats"`
+	AuthMethod string   `yaml:"authMethod"`
+	Subdomain  bool     `yaml:"subdomain"`
 }
 
 type RecipeSection struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	NamespacePrefix string    `yaml:"namespacePrefix"`
 	Endpoint        string    `yaml:"endpoint"`
 	LockProfile     string    `yaml:"lockProfile"`
-	metadata        *Metadata ``
+	metadata        *Metadata
 	ReportErrors    bool      `yaml:"reportErrors"`
 }
 


### PR DESCRIPTION
## Summary
Some applications do have multiple oidc redirect uris we'll need to auto-configure, eg vault.  This will allow us to do that

## Test Plan
Ensure compiles locally

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.