### PR TITLE
Auto-Infer Git User in Cloud Shell

### DIFF
--- a/pkg/server/setup.go
+++ b/pkg/server/setup.go
@@ -40,13 +40,20 @@ func toManifest(setup *SetupRequest) *manifest.ProjectManifest {
 
 func toContext(setup *SetupRequest) *manifest.Context {
 	ctx := manifest.NewContext()
+	consoleConf := map[string]interface{}{
+		"private_key": setup.SshPrivateKey,
+		"public_key":  setup.SshPublicKey,
+		"passphrase":  "",
+		"repo_url":    setup.GitUrl,
+	}
+
+	if setup.GitInfo != nil {
+		consoleConf["git_email"] = setup.GitInfo.Email
+		consoleConf["git_user"] = setup.GitInfo.Username
+	}
+
 	ctx.Configuration = map[string]map[string]interface{}{
-		"console": map[string]interface{}{
-			"private_key": setup.SshPrivateKey,
-			"public_key":  setup.SshPublicKey,
-			"passphrase":  "",
-			"repo_url":    setup.GitUrl,
-		},
+		"console": consoleConf,
 	}
 	return ctx
 }

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -29,6 +29,11 @@ type User struct {
 	AccessToken string `json:"access_token"`
 }
 
+type GitInfo struct {
+	Username    string `json:"username"`
+	Email       string `json:"email"`
+}
+
 type SetupRequest struct {
 	Workspace     *Workspace   `json:"workspace"`
 	Credentials   *Credentials `json:"credentials"`
@@ -36,6 +41,7 @@ type SetupRequest struct {
 	Provider      string       `json:"provider"`
 	AesKey        string       `json:"aes_key"`
 	GitUrl        string       `json:"git_url"`
+	GitInfo       *GitInfo     `json:"git_info"`
 	SshPublicKey  string       `json:"ssh_public_key"`
 	SshPrivateKey string       `json:"ssh_private_key"`
 }


### PR DESCRIPTION
## Summary
We technically get enough information to do this during the oauth handshake, so might as well autofill.


## Test Plan
compiles

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.

Fixes PLU-25