### PR TITLE
Reorder `plural init` flow to prevent repo recreation

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -9,8 +9,11 @@ import (
 	"github.com/pluralsh/plural/pkg/api"
 	"github.com/pluralsh/plural/pkg/utils"
 	"github.com/pluralsh/plural/pkg/utils/pathing"
+	"github.com/AlecAivazis/survey/v2"
 	"gopkg.in/yaml.v2"
 )
+
+type Writer func() error
 
 func ProjectManifestPath() string {
 	root, found := utils.ProjectRoot()
@@ -105,7 +108,7 @@ func Read(path string) (man *Manifest, err error) {
 	return
 }
 
-func (man *ProjectManifest) Configure() error {
+func (man *ProjectManifest) Configure() Writer {
 	utils.Highlight("\nLet's get some final information about your workspace set up\n\n")
 
 	res, _ := utils.ReadAlphaNum("Give us a unique, memorable string to use for bucket naming, eg an abbreviation for your company: ")
@@ -113,10 +116,10 @@ func (man *ProjectManifest) Configure() error {
 	man.Bucket = fmt.Sprintf("%s-tf-state", res)
 
 	if err := man.ConfigureNetwork(); err != nil {
-		return err
+		return nil
 	}
 
-	return man.Write(ProjectManifestPath())
+	return func() error { return man.Write(ProjectManifestPath()) }
 }
 
 func (man *ProjectManifest) ConfigureNetwork() error {
@@ -125,36 +128,33 @@ func (man *ProjectManifest) ConfigureNetwork() error {
 	}
 
 	utils.Highlight("\nOk, let's get your network configuration set up now...\n")
-	res, _ := utils.ReadLine("Do you want to use plural's dns provider: [Yn] ")
-	pluralDns := res != "n"
+	pluralDns := utils.Confirm("Do you want to use plural's dns provider?")
 	modifier := " (eg something.mydomain.com)"
 	if pluralDns {
 		modifier = ", must be a subdomain under onplural.sh"
 	}
 
-	subdomain := utils.UntilInputValid(
-		func() (string, error) {
-			return utils.ReadLine(fmt.Sprintf("\nWhat do you want to use as your domain%s: ", modifier))
-		},
-		func(val string) error {
-			if err := utils.ValidateDns(val); err != nil {
-				return err
-			}
+	subdomain := ""
+	input := &survey.Input{Message: fmt.Sprintf("\nWhat do you want to use as your domain%s: ", modifier)}
+	survey.AskOne(input, &subdomain, survey.WithValidator(func(val interface{}) error {
+		res, _ := val.(string)
+		if err := utils.ValidateDns(res); err != nil {
+			return err
+		}
 
-			if pluralDns && !strings.HasSuffix(val, "onplural.sh") {
-				return fmt.Errorf("Not an onplural.sh domain")
-			}
+		if pluralDns && !strings.HasSuffix(res, "onplural.sh") {
+			return fmt.Errorf("Not an onplural.sh domain")
+		}
 
-			if pluralDns {
-				client := api.NewClient()
-				if err := client.CreateDomain(val); err != nil {
-					return fmt.Errorf("Domain %s is taken or your user doesn't have sufficient permissions to create domains", val)
-				}
+		if pluralDns {
+			client := api.NewClient()
+			if err := client.CreateDomain(res); err != nil {
+				return fmt.Errorf("Domain %s is taken or your user doesn't have sufficient permissions to create domains", val)
 			}
+		}
 
-			return nil
-		},
-	)
+		return nil
+	}))
 
 	man.Network = &NetworkConfig{Subdomain: subdomain, PluralDns: pluralDns}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -23,6 +23,7 @@ type Provider interface {
 	Context() map[string]interface{}
 	Decommision(node *v1.Node) error
 	Preflights() []*Preflight
+	Flush() error
 }
 
 type Preflight struct {


### PR DESCRIPTION
## Summary

It's currently possible to create a new repo via oauth, fail to set up your cloud provider properly, then retry creating
the repo and failing because it already exists.  We should avoid that death spiral by having the provider setup come first.

I used some creative logic to get that all working using go defer funcs.

## Test Plan
tested setup locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.