### PR TITLE
Add crypto ssh-keygen command

### DIFF
--- a/cmd/plural/validation.go
+++ b/cmd/plural/validation.go
@@ -59,6 +59,16 @@ func confirmed(fn func(*cli.Context) error, msg string) func(*cli.Context) error
 	}
 }
 
+func affirmed(fn func(*cli.Context) error, msg string) func(*cli.Context) error {
+	return func(c *cli.Context) error {
+		if ok := affirm(msg); !ok {
+			return nil
+		}
+
+		return fn(c)
+	}
+}
+
 func tracked(fn func(*cli.Context) error, event string) func(*cli.Context) error {
 	return func(c *cli.Context) error {
 		event := api.UserEventAttributes{Data: "", Event: event, Status: "OK"}

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -69,7 +69,7 @@ func (gh *Github) Setup() (con Context, err error) {
 	}
 	survey.AskOne(prompt, &org, survey.WithValidator(survey.Required))
 
-	pub, priv, err := generateKeys()
+	pub, priv, err := GenerateKeys()
 	if err != nil {
 		return
 	}

--- a/pkg/scm/gitlab.go
+++ b/pkg/scm/gitlab.go
@@ -75,7 +75,7 @@ func (gl *Gitlab) Setup() (con Context, err error) {
 	}
 	survey.AskOne(prompt, &org, survey.WithValidator(survey.Required))
 
-	pub, priv, err := generateKeys()
+	pub, priv, err := GenerateKeys()
 	if err != nil {
 		return
 	}

--- a/pkg/scm/keys.go
+++ b/pkg/scm/keys.go
@@ -18,7 +18,7 @@ type keys struct {
 	priv string
 }
 
-func generateKeys() (pub string, priv string, err error) {
+func GenerateKeys() (pub string, priv string, err error) {
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return

--- a/pkg/scm/provider.go
+++ b/pkg/scm/provider.go
@@ -42,7 +42,7 @@ func Setup() (string, error) {
 		return "", err
 	}
 
-	utils.Highlight("Cloning the repo locally (be sure you have git ssh auth set up)\n")
+	utils.Highlight("Cloning the repo locally (be sure you have git ssh auth set up, you can use `plural crypto ssh-keygen` to create your first ssh keys then upload the public key to your git provider)\n")
 	auth, _ := git.SSHAuth("git", ctx.priv, "")
 	if _, err := git.Clone(auth, ctx.url, ctx.repoName); err != nil {
 		return "", err


### PR DESCRIPTION
## Summary

Since the new git oauth system autoclones with ssh, we should probably make it easier for users to setup git ssh.  I usually find generating keys to be tricky, so this command should help.



## Test Plan
compile, run locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.