### PR TITLE
Don't allow restricted bundles to be installed in cloud shell

### DIFF
--- a/cmd/plural/deploy.go
+++ b/cmd/plural/deploy.go
@@ -132,7 +132,7 @@ func doBuild(client *api.Client, installation *api.Installation, force bool) err
 	fmt.Printf("Building workspace for %s\n", repoName)
 
 	if !wkspace.Configured(repoName) {
-		return fmt.Errorf("You have not locally configured %s but have it registered as an installation, either delete it in app.plural.sh or install it locally via a bundle in `plural bundle list %s`", repoName, repoName)
+		return fmt.Errorf("You have not locally configured %s but have it registered as an installation in our api, either delete it in app.plural.sh or install it locally via a bundle in `plural bundle list %s`", repoName, repoName)
 	}
 
 	workspace, err := wkspace.New(client, installation)

--- a/pkg/api/models.go
+++ b/pkg/api/models.go
@@ -168,6 +168,7 @@ type Recipe struct {
 	Name               string
 	Provider           string
 	Description        string
+	Restricted         bool
 	Tests              []*RecipeTest
 	Repository         *Repository
 	RecipeSections     []*RecipeSection
@@ -486,6 +487,7 @@ const RecipeFragment = `
 		id
     name
     description
+	restricted
     provider
 		tests {
 			type

--- a/pkg/api/recipes.go
+++ b/pkg/api/recipes.go
@@ -9,6 +9,7 @@ type RecipeInput struct {
 	Name         string
 	Description  string
 	Provider     string
+	Restricted   bool
 	Tests        []RecipeTestInput `yaml:"tests",json:"tests,omitempty"`
 	Sections     []RecipeSectionInput
 	Dependencies []DependencyInput

--- a/pkg/bundle/installer.go
+++ b/pkg/bundle/installer.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/inancgumus/screen"
 	"github.com/pluralsh/plural/pkg/api"
@@ -15,6 +16,10 @@ func Install(repo, name string, refresh bool) error {
 	recipe, err := client.GetRecipe(repo, name)
 	if err != nil {
 		return err
+	}
+
+	if recipe.Restricted && os.Getenv("CLOUD_SHELL") == "1" {
+		return fmt.Errorf("Cannot install this bundle in cloud shell, this is often because it requires a file locally available on your machine like a git ssh key")
 	}
 
 	path := manifest.ContextPath()

--- a/pkg/bundle/tests/git.go
+++ b/pkg/bundle/tests/git.go
@@ -51,6 +51,9 @@ func authMethod(args map[string]*ContextValue) (transport.AuthMethod, error) {
 		passphrase = passArg.Val.(string)
 	}
 
-	user, _, _, _ := git.UrlComponents(url)
+	user, _, _, _, err := git.UrlComponents(url)
+	if err != nil {
+		return nil, err
+	}
 	return git.SSHAuth(user, pk, passphrase)
 }

--- a/pkg/utils/git/auth.go
+++ b/pkg/utils/git/auth.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -13,9 +14,14 @@ var (
 	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?:\/|:))?(?P<path>[^\\].*\/[^\\].*)$`)
 )
 
-func UrlComponents(url string) (user, host, port, path string) {
+func UrlComponents(url string) (user, host, port, path string, err error) {
 	m := scpLikeUrlRegExp.FindStringSubmatch(url)
-	return m[1], m[2], m[3], m[4]
+	if len(m) < 5 {
+		err = fmt.Errorf("%s is not a valid git ssh url", url)
+		return
+	}
+
+	return m[1], m[2], m[3], m[4], nil
 }
 
 func BasicAuth(user, password string) (transport.AuthMethod, error) {


### PR DESCRIPTION
## Summary

this will prevent bundles like airflow's which requires ssh keys from tripping users up



## Test Plan
tested locally


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.

Fixes ENG-179