### PR TITLE
AWS: don't set bucket constraint for us-east-1

### DIFF
--- a/pkg/provider/aws.go
+++ b/pkg/provider/aws.go
@@ -169,14 +169,18 @@ func (p *AWSProvider) mkBucket(name string) error {
 	_, err := client.HeadBucket(*p.goContext, &s3.HeadBucketInput{Bucket: &name})
 
 	if err != nil {
-		_, err = client.CreateBucket(*p.goContext,
-			&s3.CreateBucketInput{
-				Bucket: &name,
-				CreateBucketConfiguration: &s3Types.CreateBucketConfiguration{
-					LocationConstraint: s3Types.BucketLocationConstraint(p.Region()),
-				},
-			},
-		)
+
+		bucket := &s3.CreateBucketInput{
+			Bucket: &name,
+		}
+
+		if p.Region() != "us-east-1" {
+			bucket.CreateBucketConfiguration = &s3Types.CreateBucketConfiguration{
+				LocationConstraint: s3Types.BucketLocationConstraint(p.Region()),
+			}
+		}
+
+		_, err = client.CreateBucket(*p.goContext, bucket)
 		return err
 	}
 


### PR DESCRIPTION
## Summary
Apparently you can't set a bucket constraint for `us-east-1` because that is the default location. This PR should take care of that.


## Test Plan
Test locally. Haven't tested it yet.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.