### PR TITLE
ENG-210 don't save ssh keys on plural init

### DIFF
--- a/cmd/plural/crypto.go
+++ b/cmd/plural/crypto.go
@@ -8,13 +8,14 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/mitchellh/go-homedir"
+	"github.com/urfave/cli"
+
 	"github.com/pluralsh/plural/pkg/crypto"
+	"github.com/pluralsh/plural/pkg/scm"
 	"github.com/pluralsh/plural/pkg/utils"
 	"github.com/pluralsh/plural/pkg/utils/git"
-	"github.com/pluralsh/plural/pkg/scm"
-	homedir "github.com/mitchellh/go-homedir"
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/urfave/cli"
 )
 
 var prefix = []byte("CHARTMART-ENCRYPTED")
@@ -85,8 +86,8 @@ func cryptoCommands() []cli.Command {
 			},
 		},
 		{
-			Name: "ssh-keygen",
-			Usage: "generate an ed5519 keypair for use in git ssh",
+			Name:   "ssh-keygen",
+			Usage:  "generate an ed5519 keypair for use in git ssh",
 			Action: affirmed(handleKeygen, "This command will autogenerate an ed5519 keypair, without passphrase. Sound good?"),
 		},
 		{
@@ -288,14 +289,14 @@ func handleKeygen(c *cli.Context) error {
 		return err
 	}
 
-	pub, priv, err := scm.GenerateKeys()
+	pub, priv, err := scm.GenerateKeys(false)
 	if err != nil {
 		return err
 	}
 
 	filename := ""
 	input := &survey.Input{Message: "What do you want to name your keypair?", Default: "id_plrl"}
-	err = survey.AskOne(input, &filename, survey.WithValidator(func (val interface{}) error {
+	err = survey.AskOne(input, &filename, survey.WithValidator(func(val interface{}) error {
 		name, _ := val.(string)
 		if utils.Exists(filepath.Join(path, name)) {
 			return fmt.Errorf("File ~/.ssh/%s already exists", name)
@@ -311,7 +312,7 @@ func handleKeygen(c *cli.Context) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(path, filename + ".pub"), []byte(pub), 0644); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(path, filename+".pub"), []byte(pub), 0644); err != nil {
 		return err
 	}
 

--- a/pkg/scm/github.go
+++ b/pkg/scm/github.go
@@ -2,10 +2,12 @@ package scm
 
 import (
 	"context"
+
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/google/go-github/v44/github"
 	"github.com/pluralsh/oauth"
 	"golang.org/x/oauth2"
-	"github.com/AlecAivazis/survey/v2"
+
 	"github.com/pluralsh/plural/pkg/utils"
 )
 
@@ -69,11 +71,11 @@ func (gh *Github) Setup() (con Context, err error) {
 	}
 	survey.AskOne(prompt, &org, survey.WithValidator(survey.Required))
 
-	pub, priv, err := GenerateKeys()
+	pub, priv, err := GenerateKeys(false)
 	if err != nil {
 		return
 	}
-	
+
 	owner := org
 	if owner == *user.Login {
 		owner = ""
@@ -101,7 +103,7 @@ func (gh *Github) Setup() (con Context, err error) {
 
 	con.pub = pub
 	con.priv = priv
-	con.username = *user.Login 
+	con.username = *user.Login
 	con.url = *repo.SSHURL
 	con.repoName = repoName
 	return

--- a/pkg/scm/gitlab.go
+++ b/pkg/scm/gitlab.go
@@ -1,9 +1,10 @@
 package scm
 
 import (
-	"github.com/pluralsh/oauth"
-	"github.com/xanzy/go-gitlab"
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/xanzy/go-gitlab"
+
+	"github.com/pluralsh/oauth"
 	"github.com/pluralsh/plural/pkg/utils"
 )
 
@@ -19,12 +20,12 @@ func (gl *Gitlab) Init() error {
 	flow := &oauth.Flow{
 		Host: &oauth.Host{
 			AuthorizeURL: "https://gitlab.com/oauth/authorize",
-			TokenURL: "https://gitlab.com/oauth/token",
+			TokenURL:     "https://gitlab.com/oauth/token",
 		},
-		ClientID: "96dc439ce4bfab647a07b96878210015ab83f173b7f5162218954a95b8c10ebe",
+		ClientID:     "96dc439ce4bfab647a07b96878210015ab83f173b7f5162218954a95b8c10ebe",
 		ClientSecret: GitlabClientSecret,
-		CallbackURI: "http://127.0.0.1:1337/callback",
-		Scopes:   []string{"api", "openid", "profile", "email"},
+		CallbackURI:  "http://127.0.0.1:1337/callback",
+		Scopes:       []string{"api", "openid", "profile", "email"},
 		ResponseType: "code",
 	}
 
@@ -75,7 +76,7 @@ func (gl *Gitlab) Setup() (con Context, err error) {
 	}
 	survey.AskOne(prompt, &org, survey.WithValidator(survey.Required))
 
-	pub, priv, err := GenerateKeys()
+	pub, priv, err := GenerateKeys(false)
 	if err != nil {
 		return
 	}

--- a/pkg/scm/keys.go
+++ b/pkg/scm/keys.go
@@ -1,16 +1,18 @@
 package scm
 
 import (
-	"os"
-	"io/ioutil"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
-	"golang.org/x/crypto/ssh"
-	"github.com/mikesmitty/edkey"
-	"github.com/pluralsh/plural/pkg/utils"
-	homedir "github.com/mitchellh/go-homedir"
+	"io/ioutil"
+	"os"
 	"path/filepath"
+
+	"github.com/mikesmitty/edkey"
+	"github.com/mitchellh/go-homedir"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/pluralsh/plural/pkg/utils"
 )
 
 type keys struct {
@@ -18,7 +20,7 @@ type keys struct {
 	priv string
 }
 
-func GenerateKeys() (pub string, priv string, err error) {
+func GenerateKeys(saveKeyFiles bool) (pub string, priv string, err error) {
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return
@@ -35,7 +37,11 @@ func GenerateKeys() (pub string, priv string, err error) {
 	}
 	pub = string(ssh.MarshalAuthorizedKey(sshPub))
 
-	err = saveKeys(pub, priv)
+	if saveKeyFiles {
+		err = saveKeys(pub, priv)
+		return
+	}
+
 	return
 }
 


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
This PR allows configuring the function for SSH keys. Saving SSH key files can be skipped.
The source code was formatted by gofmt.

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.