### PR TITLE
use provider template versions for TF modules

### DIFF
--- a/pkg/api/models.go
+++ b/pkg/api/models.go
@@ -72,6 +72,7 @@ type Dependencies struct {
 	Wait            bool
 	ProviderWirings map[string]interface{}
 	Outputs         map[string]string
+	ProviderVsn     string
 }
 
 type Dependency struct {
@@ -388,6 +389,7 @@ const DependenciesFragment = `
 		wirings { terraform helm }
 		providerWirings
 		outputs
+		providerVsn
 	}
 `
 

--- a/pkg/api/scaffolds.go
+++ b/pkg/api/scaffolds.go
@@ -7,8 +7,8 @@ var TfProvidersQuery = `
 `
 
 var TfProviderQuery = `
-	query Provider($name: Provider!) {
-		terraformProvider(name: $name) {
+	query Provider($name: Provider!, $vsn: String) {
+		terraformProvider(name: $name, vsn: $vsn) {
 			name
 			content
 		}
@@ -24,7 +24,7 @@ func (client *Client) GetTfProviders() ([]string, error) {
 	return resp.TerraformProviders, err
 }
 
-func (client *Client) GetTfProviderScaffold(name string) (string, error) {
+func (client *Client) GetTfProviderScaffold(name, version string) (string, error) {
 	var resp struct {
 		TerraformProvider struct {
 			Name    string
@@ -33,6 +33,7 @@ func (client *Client) GetTfProviderScaffold(name string) (string, error) {
 	}
 	req := client.Build(TfProviderQuery)
 	req.Var("name", name)
+	req.Var("vsn", version)
 	err := client.Run(req, &resp)
 	return resp.TerraformProvider.Content, err
 }

--- a/pkg/provider/aws.go
+++ b/pkg/provider/aws.go
@@ -134,7 +134,7 @@ func getClient(region string, context context.Context) (*s3.Client, error) {
 	return s3.NewFromConfig(cfg), nil
 }
 
-func (aws *AWSProvider) CreateBackend(prefix string, ctx map[string]interface{}) (string, error) {
+func (aws *AWSProvider) CreateBackend(prefix string, version string, ctx map[string]interface{}) (string, error) {
 	if err := aws.mkBucket(aws.bucket); err != nil {
 		return "", errors.ErrorWrap(err, fmt.Sprintf("Failed to create terraform state bucket %s", aws.bucket))
 	}
@@ -146,7 +146,7 @@ func (aws *AWSProvider) CreateBackend(prefix string, ctx map[string]interface{})
 	if _, ok := ctx["Cluster"]; !ok {
 		ctx["Cluster"] = fmt.Sprintf("\"%s\"", aws.Cluster())
 	}
-	scaffold, err := GetProviderScaffold("AWS")
+	scaffold, err := GetProviderScaffold("AWS", version)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -129,7 +129,7 @@ func azureFromManifest(man *manifest.ProjectManifest) (*AzureProvider, error) {
 	return &AzureProvider{man.Cluster, man.Project, man.Bucket, man.Region, man.Context, nil}, nil
 }
 
-func (azure *AzureProvider) CreateBackend(prefix string, ctx map[string]interface{}) (string, error) {
+func (azure *AzureProvider) CreateBackend(prefix string, version string, ctx map[string]interface{}) (string, error) {
 	if err := azure.CreateBucket(azure.bucket); err != nil {
 		return "", errors.ErrorWrap(err, fmt.Sprintf("Failed to create terraform state bucket %s", azure.bucket))
 	}
@@ -147,7 +147,7 @@ func (azure *AzureProvider) CreateBackend(prefix string, ctx map[string]interfac
 		ctx["Cluster"] = fmt.Sprintf(`"%s"`, azure.Cluster())
 	}
 
-	scaffold, err := GetProviderScaffold("AZURE")
+	scaffold, err := GetProviderScaffold("AZURE", version)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/provider/equinix.go
+++ b/pkg/provider/equinix.go
@@ -112,7 +112,7 @@ func equinixFromManifest(man *manifest.ProjectManifest) (*EQUINIXProvider, error
 	return &EQUINIXProvider{man.Cluster, man.Project, man.Bucket, man.Region, man.Context, nil}, nil
 }
 
-func (equinix *EQUINIXProvider) CreateBackend(prefix string, ctx map[string]interface{}) (string, error) {
+func (equinix *EQUINIXProvider) CreateBackend(prefix string, version string, ctx map[string]interface{}) (string, error) {
 
 	ctx["Region"] = equinix.Region()
 	ctx["Bucket"] = equinix.Bucket()
@@ -132,7 +132,7 @@ func (equinix *EQUINIXProvider) CreateBackend(prefix string, ctx map[string]inte
 	if err := utils.WriteFile(pathing.SanitizeFilepath(filepath.Join(equinix.Bucket(), ".gitattributes")), []byte("/** filter=plural-crypt diff=plural-crypt\n.gitattributes !filter !diff")); err != nil {
 		return "", err
 	}
-	scaffold, err := GetProviderScaffold("EQUINIX")
+	scaffold, err := GetProviderScaffold("EQUINIX", version)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/provider/gcp.go
+++ b/pkg/provider/gcp.go
@@ -188,7 +188,7 @@ func (gcp *GCPProvider) Flush() error {
 	return gcp.writer()
 }
 
-func (gcp *GCPProvider) CreateBackend(prefix string, ctx map[string]interface{}) (string, error) {
+func (gcp *GCPProvider) CreateBackend(prefix string, version string, ctx map[string]interface{}) (string, error) {
 	if err := gcp.mkBucket(gcp.bucket); err != nil {
 		return "", errors.ErrorWrap(err, fmt.Sprintf("Failed to create terraform state bucket %s", gcp.Bucket()))
 	}
@@ -207,7 +207,7 @@ func (gcp *GCPProvider) CreateBackend(prefix string, ctx map[string]interface{})
 	} else {
 		ctx["Cluster"] = fmt.Sprintf(`"%s"`, gcp.Cluster())
 	}
-	scaffold, err := GetProviderScaffold("GCP")
+	scaffold, err := GetProviderScaffold("GCP", version)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/provider/kind.go
+++ b/pkg/provider/kind.go
@@ -66,7 +66,7 @@ func kindFromManifest(man *manifest.ProjectManifest) (*KINDProvider, error) {
 	return &KINDProvider{man.Cluster, man.Project, man.Bucket, man.Region, man.Context, nil}, nil
 }
 
-func (kind *KINDProvider) CreateBackend(prefix string, ctx map[string]interface{}) (string, error) {
+func (kind *KINDProvider) CreateBackend(prefix string, version string, ctx map[string]interface{}) (string, error) {
 
 	ctx["Region"] = kind.Region()
 	ctx["Bucket"] = kind.Bucket()
@@ -86,7 +86,7 @@ func (kind *KINDProvider) CreateBackend(prefix string, ctx map[string]interface{
 	if err := utils.WriteFile(pathing.SanitizeFilepath(filepath.Join(kind.Bucket(), ".gitattributes")), []byte("/** filter=plural-crypt diff=plural-crypt\n.gitattributes !filter !diff")); err != nil {
 		return "", err
 	}
-	scaffold, err := GetProviderScaffold("KIND")
+	scaffold, err := GetProviderScaffold("KIND", version)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -19,7 +19,7 @@ type Provider interface {
 	Region() string
 	Bucket() string
 	KubeConfig() error
-	CreateBackend(prefix string, ctx map[string]interface{}) (string, error)
+	CreateBackend(prefix string, version string, ctx map[string]interface{}) (string, error)
 	Context() map[string]interface{}
 	Decommision(node *v1.Node) error
 	Preflights() []*Preflight
@@ -49,14 +49,14 @@ type Providers struct {
 
 var providers = Providers{}
 
-func GetProviderScaffold(provider string) (string, error) {
+func GetProviderScaffold(provider, version string) (string, error) {
 	if providers.Scaffolds == nil {
 		providers.Scaffolds = make(map[string]string)
 	}
 	_, ok := providers.Scaffolds[provider]
 	if !ok {
 		client := api.NewClient()
-		scaffold, err := client.GetTfProviderScaffold(provider)
+		scaffold, err := client.GetTfProviderScaffold(provider, version)
 		providers.Scaffolds[provider] = scaffold
 		if err != nil {
 			return "", err

--- a/pkg/scaffold/terraform.go
+++ b/pkg/scaffold/terraform.go
@@ -49,6 +49,8 @@ func (scaffold *Scaffold) handleTerraform(wk *wkspace.Workspace) error {
 		providerVersions = append(providerVersions, wk.Terraform[i].Terraform.Dependencies.ProviderVsn)
 	}
 
+	semver.Sort(providerVersions)
+
 	// use the latest version of the TF template for the provider
 	backend, err := wk.Provider.CreateBackend(repo.Name, providerVersions[providerVersions.Len()-1], providerCtx)
 	if err != nil {


### PR DESCRIPTION
## Summary
The API supports the ability to specify the version of the Terraform provider template to use for a module by specifying it in the `deps.yaml` file. This PR adds the support to the CLI to use this field and get the proper template version for a TF provider.

## Test Plan
Tested locally.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.