### PR TITLE
return only lock object when lock file doesn't exist

### DIFF
--- a/pkg/pluralfile/lock.go
+++ b/pkg/pluralfile/lock.go
@@ -76,7 +76,7 @@ func Lock(path string) (*Lockfile, error) {
 	lockfile := lockPath(path, conf.LockProfile)
 	content, err := ioutil.ReadFile(lockfile)
 	if err != nil {
-		return lock, err
+		return lock, nil
 	}
 
 	if err := yaml.Unmarshal(content, lock); err != nil {


### PR DESCRIPTION

## Summary
This PR fixes the` plural apply` command. The bug was introduced during linter fixes

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.