### PR TITLE
Fix setting repo privacy in cli

### DIFF
--- a/pkg/api/repos.go
+++ b/pkg/api/repos.go
@@ -44,7 +44,7 @@ type OauthSettings struct {
 type RepositoryInput struct {
 	Name          string
 	Description   string
-	Private       bool   `json:"private,omitempty" yaml:"private,omitempty"`
+	Private       bool   `json:"private" yaml:"private,omitempty"`
 	Tags          []Tag  `json:"tags,omitempty" yaml:"tags"`
 	Icon          string `json:"icon,omitempty" yaml:"icon"`
 	DarkIcon      string `json:"darkIcon,omitempty" yaml:"darkIcon"`


### PR DESCRIPTION
## Summary

Previously we could make things private but not public, which apparently is from the omitempty struct tag that was in place 

## Test Plan
tested by updating kubescape


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.