### PR TITLE
ENG-396 ENG-401 fix OauthSettings in repository.yaml

### DIFF
--- a/pkg/api/repos.go
+++ b/pkg/api/repos.go
@@ -234,23 +234,36 @@ func ConstructRepositoryInput(marshalled []byte) (input *RepositoryInput, err er
 }
 
 func ConstructGqlClientRepositoryInput(marshalled []byte) (*gqlclient.RepositoryAttributes, error) {
-	input := &gqlclient.RepositoryAttributes{}
-	if err := yaml.Unmarshal(marshalled, input); err != nil {
+	repoInput, err := ConstructRepositoryInput(marshalled)
+	if err != nil {
 		return nil, err
 	}
-	return input, nil
-}
 
-func ConstructResourceDefinition(marshalled []byte) (input gqlclient.ResourceDefinitionAttributes, err error) {
-	err = yaml.Unmarshal(marshalled, &input)
-	return
-}
+	category := gqlclient.Category(repoInput.Category)
 
-func ConstructIntegration(marshalled []byte) (gqlclient.IntegrationAttributes, error) {
-	intAttr := gqlclient.IntegrationAttributes{}
-	err := yaml.Unmarshal(marshalled, &intAttr)
-	if err != nil {
-		return gqlclient.IntegrationAttributes{}, err
+	resp := &gqlclient.RepositoryAttributes{
+		Category:    &category,
+		DarkIcon:    &repoInput.DarkIcon,
+		Description: &repoInput.Description,
+		GitURL:      &repoInput.GitUrl,
+		Homepage:    &repoInput.Homepage,
+		Icon:        &repoInput.Icon,
+		Name:        &repoInput.Name,
+		Notes:       &repoInput.Notes,
+		Private:     &repoInput.Private,
+		Tags:        []*gqlclient.TagAttributes{},
 	}
-	return intAttr, nil
+	if repoInput.OauthSettings != nil {
+		resp.OauthSettings = &gqlclient.OauthSettingsAttributes{
+			AuthMethod: gqlclient.OidcAuthMethod(repoInput.OauthSettings.AuthMethod),
+			URIFormat:  repoInput.OauthSettings.UriFormat,
+		}
+	}
+	for _, tag := range repoInput.Tags {
+		resp.Tags = append(resp.Tags, &gqlclient.TagAttributes{
+			Tag: tag.Tag,
+		})
+	}
+
+	return resp, nil
 }

--- a/pkg/api/repos_test.go
+++ b/pkg/api/repos_test.go
@@ -1,0 +1,72 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/pluralsh/gqlclient"
+	"github.com/pluralsh/plural/pkg/api"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConstructGqlClientRepositoryInput(t *testing.T) {
+	devopsCategory := gqlclient.CategoryDevops
+	testDescription := "test"
+	privateFlag := true
+	icon := "plural/icons/test.png"
+	notes := "plural/notes.tpl"
+	name := "test"
+	emptyString := ""
+
+	tests := []struct {
+		name     string
+		input    string
+		expected *gqlclient.RepositoryAttributes
+	}{
+		{
+			name: `test repository.yaml conversion`,
+			expected: &gqlclient.RepositoryAttributes{
+				Category:    &devopsCategory,
+				DarkIcon:    &emptyString,
+				Description: &testDescription,
+				GitURL:      &emptyString,
+				Homepage:    &emptyString,
+				Icon:        &icon,
+				Name:        &name,
+				Notes:       &notes,
+				OauthSettings: &gqlclient.OauthSettingsAttributes{
+					AuthMethod: "POST",
+					URIFormat:  "https://{domain}/oauth2/callback",
+				},
+				Private: &privateFlag,
+				Readme:  nil,
+				Secrets: nil,
+				Tags: []*gqlclient.TagAttributes{
+					{
+						Tag: "data-science",
+					},
+				},
+				Verified: nil,
+			},
+			input: `name: test
+description: test
+category: DEVOPS
+private: true
+icon: plural/icons/test.png
+notes: plural/notes.tpl
+oauthSettings:
+  uriFormat: https://{domain}/oauth2/callback
+  authMethod: POST
+tags:
+- tag: data-science
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repositoryAttributes, err := api.ConstructGqlClientRepositoryInput([]byte(test.input))
+			assert.NoError(t, err)
+			assert.Equal(t, repositoryAttributes, test.expected)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
The YAML unmarshal method for RepositoryAttributes couldn't parse OauthSettings. This PR fixes this issue.


## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.