### PR TITLE
ENG-430 print what next after repos reset

### DIFF
--- a/cmd/plural/repos.go
+++ b/cmd/plural/repos.go
@@ -90,5 +90,6 @@ func (p *Plural) handleResetInstallations(c *cli.Context) error {
 
 	fmt.Printf("Deleted %d installations in app.plural.sh\n", count)
 	fmt.Println("(you can recreate these at any time and any running infrastructure is not affected, plural will simply no longer deliver upgrades)")
+	utils.Note("Now run `plural bundle install <repo> <bundle-name>` to install a new app \n")
 	return nil
 }


### PR DESCRIPTION
## Summary
After plural repos reset is run, print a message that tells the user which command to run next

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.