### PR TITLE
Update `plural version` command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,10 @@ jobs:
           context: .
           file: ./Dockerfile
           push: false
+          build-args: |
+            APP_VSN=ci
+            APP_COMMIT=$GITHUB_SHA
+            APP_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S%z")
   cloud:
     name: Build cloud image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,9 @@ jobs:
           file: ./Dockerfile
           push: false
           build-args: |
-            APP_VSN=ci
-            APP_COMMIT=$GITHUB_SHA
-            APP_DATE=2006-01-02T15:04:05+0700
+            APP_VSN=dev
+            APP_COMMIT=
+            APP_DATE=
   cloud:
     name: Build cloud image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           build-args: |
             APP_VSN=ci
             APP_COMMIT=$GITHUB_SHA
-            APP_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S%z")
+            APP_DATE=2006-01-02T15:04:05+0700
   cloud:
     name: Build cloud image
     runs-on: ubuntu-latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     ldflags:
-    - "-s -w -X main.Version={{.Version}} -X main.GitCommit={{.Commit}} -X github.com/pluralsh/plural/pkg/scm.GitlabClientSecret={{ .Env.GITLAB_CLIENT_SECRET }}"
+    - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X github.com/pluralsh/plural/pkg/scm.GitlabClientSecret={{ .Env.GITLAB_CLIENT_SECRET }}"
     goos:
       - linux
       - windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,11 +34,12 @@ changelog:
       - '^test:'
 release:
   name_template: "{{.ProjectName}}-v{{.Version}}"
+  header: |
+    ## Plural CLI release ({{ .Date }})
+    Welcome to this new release of the Plural CLI!
   footer: |
     ## Thanks!
-
     We'd like to thank all contributors for helping with improving our CLI!
-
 brews:
   - name: plural
     tap:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,10 +34,6 @@ changelog:
       - '^test:'
 release:
   name_template: "{{.ProjectName}}-v{{.Version}}"
-  header: |
-    ## Plural CLI release ({{ .Date }})
-
-    Welcome to this new release of the Plural CLI!
   footer: |
     ## Thanks!
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+ARG APP_VSN
+ARG APP_COMMIT
+ARG APP_DATE
+
 FROM ubuntu:22.10 as user
 
 # Create a nonroot user for final image
@@ -19,7 +23,9 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 OUTFILE=plural make build-cli
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -ldflags "-s -w -X main.version=${APP_VSN} -X main.commit=${APP_COMMIT} -X main.date=${APP_DATE}" \
+    -o plural ./cmd/plural/
 
 FROM gcr.io/pluralsh/golang:1.18.2-alpine3.15
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,3 +40,4 @@ COPY --from=user /etc/passwd /etc/passwd
 USER nonroot
 
 RUN /go/bin/plural --help
+RUN /go/bin/plural version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-ARG APP_VSN
-ARG APP_COMMIT
-ARG APP_DATE
-
 FROM ubuntu:22.10 as user
 
 # Create a nonroot user for final image
@@ -23,6 +19,10 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
+ARG APP_VSN
+ARG APP_COMMIT
+ARG APP_DATE
+
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build -ldflags "-s -w -X main.version=${APP_VSN} -X main.commit=${APP_COMMIT} -X main.date=${APP_DATE}" \
     -o plural ./cmd/plural/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o plural -ldflags '-s -w' ./cmd/plural/
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 OUTFILE=plural make build-cli
 
 FROM gcr.io/pluralsh/golang:1.18.2-alpine3.15
 

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ plural: .PHONY ## uploads to plural
 build: .PHONY ## Build the Docker image
 	docker build --build-arg APP_NAME=$(APP_NAME) \
 		--build-arg APP_VSN=$(APP_VSN) \
+		--build-arg APP_DATE=$(APP_DATE) \
+		--build-arg APP_COMMIT=$(BUILD) \
 		-t $(APP_NAME):$(APP_VSN) \
 		-t $(APP_NAME):latest \
 		-t gcr.io/$(GCP_PROJECT)/$(APP_NAME):$(APP_VSN) \

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@
 GCP_PROJECT ?= pluralsh
 APP_NAME ?= plural-cli
 APP_VSN ?= $(shell git describe --tags --always --dirty)
-APP_TIMESTAMP ?= $(shell date -u +"%Y-%m-%dT%H:%M:%S%z")
+APP_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%S%z")
 BUILD ?= $(shell git rev-parse --short HEAD)
 DKR_HOST ?= dkr.plural.sh
 GOOS ?= darwin
 GOARCH ?= amd64
-BASE_LDFLAGS ?= -X main.GitCommit=$(BUILD) -X main.Version=$(APP_VSN) -X main.CompiledAt=$(APP_TIMESTAMP) -X github.com/pluralsh/plural/pkg/scm.GitlabClientSecret=${GITLAB_CLIENT_SECRET}
+BASE_LDFLAGS ?= -X main.version=$(APP_VSN) -X main.commit=$(BUILD) -X main.date=$(APP_DATE) -X github.com/pluralsh/plural/pkg/scm.GitlabClientSecret=${GITLAB_CLIENT_SECRET}
 OUTFILE ?= plural.o
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@
 GCP_PROJECT ?= pluralsh
 APP_NAME ?= plural-cli
 APP_VSN ?= $(shell git describe --tags --always --dirty)
+APP_TIMESTAMP ?= $(shell date -u +"%Y-%m-%dT%H:%M:%S%z")
 BUILD ?= $(shell git rev-parse --short HEAD)
 DKR_HOST ?= dkr.plural.sh
 GOOS ?= darwin
 GOARCH ?= amd64
-BASE_LDFLAGS ?= -X main.GitCommit=$(BUILD) -X main.Version=$(APP_VSN) -X github.com/pluralsh/plural/pkg/scm.GitlabClientSecret=${GITLAB_CLIENT_SECRET}
+BASE_LDFLAGS ?= -X main.GitCommit=$(BUILD) -X main.Version=$(APP_VSN) -X main.CompiledAt=$(APP_TIMESTAMP) -X github.com/pluralsh/plural/pkg/scm.GitlabClientSecret=${GITLAB_CLIENT_SECRET}
 OUTFILE ?= plural.o
 
 help:

--- a/cmd/plural/version.go
+++ b/cmd/plural/version.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/pluralsh/plural/pkg/utils"
 	"github.com/urfave/cli"
@@ -16,7 +15,7 @@ import (
 var (
 	version = "dev"
 	commit  = ""
-	date    = time.Now().Format(time.RFC3339)
+	date    = ""
 )
 
 const latestUri = "https://api.github.com/repos/pluralsh/plural-cli/commits/master"

--- a/cmd/plural/version.go
+++ b/cmd/plural/version.go
@@ -68,7 +68,5 @@ func versionInfo(c *cli.Context) error {
 	fmt.Printf("   compiled at\t%s\n", date)
 	fmt.Printf("   os/arch\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
 
-	checkRecency()
-
-	return nil
+	return checkRecency()
 }

--- a/cmd/plural/version.go
+++ b/cmd/plural/version.go
@@ -13,17 +13,17 @@ import (
 )
 
 const (
-	devVersion = "dev"
-	latestURI  = "https://api.github.com/repos/pluralsh/plural-cli/releases/latest"
+	versionPlaceholder = "dev"
+	latestURI          = "https://api.github.com/repos/pluralsh/plural-cli/releases/latest"
 )
 
 var (
-	version = devVersion
+	version = versionPlaceholder
 	commit  = ""
 	date    = ""
 )
 
-func latestVersion() (res string, err error) {
+func getLatestVersion() (res string, err error) {
 	resp, err := http.Get(latestURI)
 	if err != nil {
 		return
@@ -45,11 +45,13 @@ func latestVersion() (res string, err error) {
 }
 
 func checkRecency() error {
-	if version == devVersion {
+	if version == versionPlaceholder || strings.Contains(version, "-") {
+		utils.Warn("\nThis is a development version, which can be significantly different from official releases")
+		utils.Warn("\nYou can download latest release from https://github.com/pluralsh/plural-cli/releases/latest\n")
 		return nil
 	}
 
-	latestVersion, err := latestVersion()
+	latestVersion, err := getLatestVersion()
 	if err != nil {
 		return err
 	}

--- a/cmd/plural/version.go
+++ b/cmd/plural/version.go
@@ -14,11 +14,10 @@ import (
 )
 
 var (
-	GitCommit string
-	Version   string
+	GitCommit  = "n/a"
+	Version    = "dev"
+	CompiledAt = time.Now().Format(time.RFC3339)
 )
-
-var BuildDate = time.Now()
 
 const latestUri = "https://api.github.com/repos/pluralsh/plural-cli/commits/master"
 
@@ -59,7 +58,7 @@ func versionInfo(c *cli.Context) error {
 	fmt.Println("Plural CLI:")
 	fmt.Printf("  Version: %s\n", Version)
 	fmt.Printf("  Git Commit: %s\n", GitCommit)
-	fmt.Printf("  Compiled At: %s\n", BuildDate.String())
+	fmt.Printf("  Compiled At: %s\n", CompiledAt)
 	fmt.Printf("  OS: %s\n", runtime.GOOS)
 	fmt.Printf("  Arch: %s\n", runtime.GOARCH)
 	return nil

--- a/cmd/plural/version.go
+++ b/cmd/plural/version.go
@@ -14,9 +14,9 @@ import (
 )
 
 var (
-	GitCommit  = "n/a"
-	Version    = "dev"
-	CompiledAt = time.Now().Format(time.RFC3339)
+	version = "dev"
+	commit  = ""
+	date    = time.Now().Format(time.RFC3339)
 )
 
 const latestUri = "https://api.github.com/repos/pluralsh/plural-cli/commits/master"
@@ -47,7 +47,7 @@ func checkRecency() error { //nolint:deadcode,unused
 		return err
 	}
 
-	if !strings.HasPrefix(sha, GitCommit) {
+	if !strings.HasPrefix(sha, commit) {
 		utils.Warn("Your cli version appears out of date, try updating it with your package manager\n\n")
 	}
 
@@ -55,11 +55,10 @@ func checkRecency() error { //nolint:deadcode,unused
 }
 
 func versionInfo(c *cli.Context) error {
-	fmt.Println("Plural CLI:")
-	fmt.Printf("  Version: %s\n", Version)
-	fmt.Printf("  Git Commit: %s\n", GitCommit)
-	fmt.Printf("  Compiled At: %s\n", CompiledAt)
-	fmt.Printf("  OS: %s\n", runtime.GOOS)
-	fmt.Printf("  Arch: %s\n", runtime.GOARCH)
+	fmt.Println("PLURAL CLI:")
+	fmt.Printf("   version\t%s\n", version)
+	fmt.Printf("   git commit\t%s\n", commit)
+	fmt.Printf("   compiled at\t%s\n", date)
+	fmt.Printf("   os/arch\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
 	return nil
 }

--- a/dockerfiles/Dockerfile.cloud
+++ b/dockerfiles/Dockerfile.cloud
@@ -56,6 +56,7 @@ COPY . .
 RUN make build-cli OUTFILE=/go/bin/plural && \
       cp /go/bin/plural /usr/local/bin/plural && \
       plural --help && \
+      plural version && \
       cp start-session.sh /usr/local/bin/start-session.sh && \
       chmod +x /usr/local/bin/start-session.sh
 


### PR DESCRIPTION
## Summary
- Fix `plural version` command to display compilation time set in ldflags
  - Use RFC3339 date format and UTC time zone
  - Use same names as in [goreleaser defaults](https://goreleaser.com/cookbooks/using-main.version)
  - Update format to match `plural` command (see below)
- Update build command in Dockerfile
- Restore recency check that was removed in https://github.com/pluralsh/plural-cli/commit/a017714500b929639c56e436a64d794528a1262d as [Homebrew publish is already automated](https://github.com/pluralsh/homebrew-plural/commits/main) (closes ENG-452)
  - Base check on version numbers instead of commit SHA
  - It will run only when using `plural version` command, so it will not show too often. Previously this was based on random numbers with 25% chance of warning being displayed. Would you like to restore that behavior?
- Shorten release description

<img width="758" alt="Zrzut ekranu 2022-08-9 o 10 22 26" src="https://user-images.githubusercontent.com/2823399/183601900-c407ac32-4178-4fd3-810e-65587221c343.png">

## Test Plan
Tested manually.

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.