### PR TITLE
Fix crypto error handling

### DIFF
--- a/pkg/crypto/config.go
+++ b/pkg/crypto/config.go
@@ -33,15 +33,10 @@ func ReadConfig() (conf *Config, err error) {
 }
 
 func Build() (Provider, error) {
-	fallback, err := fallbackProvider()
-	if err != nil {
-		return nil, err
-	}
 	if utils.Exists(configPath()) {
 		conf, err := ReadConfig()
-
 		if err != nil {
-			return fallback, err
+			return fallbackProvider()
 		}
 
 		switch conf.Type {
@@ -52,7 +47,7 @@ func Build() (Provider, error) {
 		}
 	}
 
-	return fallback, err
+	return fallbackProvider()
 }
 
 func fallbackProvider() (*KeyProvider, error) {


### PR DESCRIPTION
The error check was being executed prematurely, which breaks some console shared repos (where the filesystem is read-only and a crypto provider fails to materialize, but you can still use the age provider)

## Test Plan
ensure compiles


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.