### PR TITLE
ENG-497 fix plural crypto recover command

### DIFF
--- a/cmd/plural/crypto.go
+++ b/cmd/plural/crypto.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mitchellh/go-homedir"
@@ -372,14 +371,13 @@ func handleRecover(c *cli.Context) error {
 	if !ok {
 		return fmt.Errorf("could not find `key` in console-conf secret")
 	}
-	keyValue := string(key)
-	prefix := "key:"
-	// the key has the structure: `key: aaabbbcccxxx\n`
-	// we have to retrieve the value
-	keyValue = strings.TrimPrefix(keyValue, prefix)
-	keyValue = strings.TrimSpace(keyValue)
 
-	if err := crypto.Setup(keyValue); err != nil {
+	aesKey, err := crypto.Import(key)
+	if err != nil {
+		return err
+	}
+
+	if err := crypto.Setup(aesKey.Key); err != nil {
 		return err
 	}
 

--- a/cmd/plural/crypto.go
+++ b/cmd/plural/crypto.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mitchellh/go-homedir"
@@ -371,8 +372,14 @@ func handleRecover(c *cli.Context) error {
 	if !ok {
 		return fmt.Errorf("could not find `key` in console-conf secret")
 	}
+	keyValue := string(key)
+	prefix := "key:"
+	// the key has the structure: `key: aaabbbcccxxx\n`
+	// we have to retrieve the value
+	keyValue = strings.TrimPrefix(keyValue, prefix)
+	keyValue = strings.TrimSpace(keyValue)
 
-	if err := crypto.Setup(string(key)); err != nil {
+	if err := crypto.Setup(keyValue); err != nil {
 		return err
 	}
 

--- a/pkg/crypto/backup.go
+++ b/pkg/crypto/backup.go
@@ -12,8 +12,11 @@ import (
 func backupKey(key string) error {
 	p := getKeyPath()
 	if utils.Exists(p) {
-		aes, _ := Read(p)
-		if aes.Key == key {
+		aes, err := Read(p)
+		if err != nil {
+			return err
+		}
+		if aes != nil && aes.Key == key {
 			return nil
 		}
 


### PR DESCRIPTION
## Summary
This PR fixes the` plural crypto recover` command. It will also fix the broken `~/.plural/key`

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.