### PR TITLE
ENG-294 support back-filling of encryption

### DIFF
--- a/cmd/plural/deploy.go
+++ b/cmd/plural/deploy.go
@@ -93,6 +93,9 @@ func diffed(_ *cli.Context) error {
 }
 
 func (p *Plural) build(c *cli.Context) error {
+	if err := CheckGitCrypt(c); err != nil {
+		return errors.ErrorWrap(errNoGit, "Failed to scan your repo for secrets to encrypt them")
+	}
 	changed, err := git.HasUpstreamChanges()
 	if err != nil {
 		return errors.ErrorWrap(errNoGit, "Failed to get git information")

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -70,3 +70,11 @@ func Exists(path string) bool {
 	_, err := os.Stat(path)
 	return !os.IsNotExist(err)
 }
+
+func CompareFileContent(filename, content string) (bool, error) {
+	c, err := ReadFile(filename)
+	if err != nil {
+		return false, err
+	}
+	return c == content, nil
+}


### PR DESCRIPTION
## Summary
Some old repositories can have fewer files to encrypt and must be updated. The new code checks some of the git files and calls the `cryptoInit` function which was only executed during the `plural init` command, now also during `plural build`.

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.