### PR TITLE
ENG-463 - Add better error handling for init step

### DIFF
--- a/cmd/plural/init.go
+++ b/cmd/plural/init.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/pkg/browser"
+	"github.com/urfave/cli"
+
 	"github.com/pluralsh/plural/pkg/api"
 	"github.com/pluralsh/plural/pkg/config"
 	"github.com/pluralsh/plural/pkg/crypto"
@@ -16,7 +18,6 @@ import (
 	"github.com/pluralsh/plural/pkg/utils"
 	"github.com/pluralsh/plural/pkg/utils/pathing"
 	"github.com/pluralsh/plural/pkg/wkspace"
-	"github.com/urfave/cli"
 )
 
 func handleInit(c *cli.Context) error {
@@ -37,7 +38,6 @@ func handleInit(c *cli.Context) error {
 	}
 	defer func(prov provider.Provider) {
 		_ = prov.Flush()
-
 	}(prov)
 
 	if !git && affirm("you're attempting to setup plural outside a git repository. would you like us to set one up for you here?") {

--- a/pkg/wkspace/validator.go
+++ b/pkg/wkspace/validator.go
@@ -23,7 +23,12 @@ func Preflight() (bool, error) {
 
 	cmd = exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	if _, err := cmd.CombinedOutput(); err != nil {
-		return false, utils.HighlightError(fmt.Errorf("Repository has no initial commit, you can simply commit a blank readme and push to start working"))
+		return true, utils.HighlightError(fmt.Errorf("repository has no initial commit, you can simply commit a blank readme and push to start working"))
+	}
+
+	cmd = exec.Command("git", "ls-remote", "--exit-code")
+	if _, err := cmd.CombinedOutput(); err != nil {
+		return true, utils.HighlightError(fmt.Errorf("repository has no remotes set, make sure that at least one remote is set"))
 	}
 
 	return true, nil


### PR DESCRIPTION
## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Added a new check to see if any remotes are set for the current git repository
- Updated existing check to actually return an early error since we know we are in a git repository at this step and we shouldn't see the message about "attempting to setup plural outside a git repository".

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Built locally with `go build`. Tested in a new directory.
1. `mkdir test`
2. `git init`
3. `./cli init`
> 2022/08/24 11:27:22 repository has no initial commit, you can simply commit a blank readme and push to start working
4. `git add .` and `git commit` any file
5. `./cli init`
> 2022/08/24 11:28:25 repository has no remotes set, make sure that at least one remote is set
6. `git remote add origin <git_repo>`
7. Proper init workflow is started

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.