### PR TITLE
init plural client in crypto commands

### DIFF
--- a/cmd/plural/crypto.go
+++ b/cmd/plural/crypto.go
@@ -262,6 +262,7 @@ func cryptoInit(c *cli.Context) error {
 }
 
 func (p *Plural) handleCryptoShare(c *cli.Context) error {
+	p.InitPluralClient()
 	emails := c.StringSlice("email")
 	if err := crypto.SetupAge(p.Client, emails); err != nil {
 		return err
@@ -276,6 +277,7 @@ func (p *Plural) handleCryptoShare(c *cli.Context) error {
 }
 
 func (p *Plural) handleSetupKeys(c *cli.Context) error {
+	p.InitPluralClient()
 	name := c.String("name")
 	if err := crypto.SetupIdentity(p.Client, name); err != nil {
 		return err


### PR DESCRIPTION
## Summary
The `plural crypto share` command was not working since the Plural client wasn't initialized. This fixes it.


## Test Plan
Test locally.


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.