### PR TITLE
Make plural repair fail silently

### DIFF
--- a/cmd/plural/git.go
+++ b/cmd/plural/git.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -14,7 +15,11 @@ func handleRepair(c *cli.Context) error {
 		return err
 	}
 
-	return git.Repair(repoRoot)
+	if err := git.Repair(repoRoot); err != nil {
+		fmt.Println(err)
+	}
+
+	return nil
 }
 
 func gitConfig(name, val string) error {


### PR DESCRIPTION
## Summary
The console can sometimes become jammed on unusual encrpytion diffs, but they can be fixed by just adding and committing all files and pushing upstream.  `plural repair` should do that, but it's not safe to use in the console if it blocks deploys, so having it always exit 0 is the safest bet.

## Test Plan
run it locally


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.