### PR TITLE
support empty notes uploads

### DIFF
--- a/cmd/plural/git.go
+++ b/cmd/plural/git.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -14,7 +15,11 @@ func handleRepair(c *cli.Context) error {
 		return err
 	}
 
-	return git.Repair(repoRoot)
+	if err := git.Repair(repoRoot); err != nil {
+		fmt.Println(err)
+	}
+
+	return nil
 }
 
 func gitConfig(name, val string) error {

--- a/pkg/api/repos.go
+++ b/pkg/api/repos.go
@@ -113,7 +113,7 @@ func (client *client) CreateRepository(name, publisher string, input *gqlclient.
 		uploads = append(uploads, *darkIconUpload)
 	}
 
-	if input.Notes != nil {
+	if input.Notes != nil && *input.Notes != "" {
 		file, _ := filepath.Abs(*input.Notes)
 		notes, err := fileutils.ReadFile(file)
 		if err != nil {


### PR DESCRIPTION
the cli wasn't uploading repo attributes w/o a notes file specified because of an annoying string ptr issue, this should fix


## Test Plan
tested locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.

Fixes ENG-649