### PR TITLE
ENG-597 fix error handling for Parse method

### DIFF
--- a/pkg/pluralfile/parse.go
+++ b/pkg/pluralfile/parse.go
@@ -57,6 +57,9 @@ func (plrl *Pluralfile) Execute(f string, lock *Lockfile) (err error) {
 
 func Parse(f string) (*Pluralfile, error) {
 	pluralfile, err := os.Open(f)
+	if err != nil {
+		return nil, err
+	}
 	plrl := &Pluralfile{}
 	if err != nil {
 		return plrl, err


### PR DESCRIPTION
## Summary
`plural apply -f xxx/Plural`, doesn't work properly. This PR fixes error handling for this command

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.