### PR TITLE
Fix normalize method

### DIFF
--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -6,7 +6,7 @@ import (
 
 func NormalizeProvider(prov string) string {
 	provider := strings.ToUpper(prov)
-	if prov == "GOOGLE" {
+	if provider == "GOOGLE" {
 		return "GCP"
 	}
 

--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -1,0 +1,27 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/pluralsh/plural/pkg/api"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeProvider(t *testing.T) {
+	tests := []struct {
+		provider string
+		expected string
+	}{
+		{provider: `aws`, expected: `AWS`},
+		{provider: `gcp`, expected: `GCP`},
+		{provider: `google`, expected: `GCP`},
+		{provider: `azure`, expected: `AZURE`},
+	}
+	for _, test := range tests {
+		t.Run(test.provider, func(t *testing.T) {
+			result := api.NormalizeProvider(test.provider)
+			assert.Equal(t, result, test.expected)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes normalize method that prevented `plural stack install ...` from working in the cloud shell.

## Test Plan
Added tests.

## Checklist
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.