### PR TITLE
Begin working on azure cloud shell support

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -146,7 +146,7 @@ func mkAzure(conf config.Config) (prov *AzureProvider, err error) {
 		return
 	}
 
-	subId, tenID, err := getAzureAccount()
+	subId, tenID, err := GetAzureAccount()
 	if err != nil {
 		return
 	}
@@ -380,7 +380,7 @@ func (az *AzureProvider) upsertStorageContainer(acc storage.Account, name string
 	return err
 }
 
-func getAzureAccount() (string, string, error) {
+func GetAzureAccount() (string, string, error) {
 	cmd := exec.Command("az", "account", "show")
 	out, err := cmd.Output()
 	if err != nil {

--- a/pkg/server/setup.go
+++ b/pkg/server/setup.go
@@ -36,6 +36,7 @@ func toManifest(setup *SetupRequest) *manifest.ProjectManifest {
 			PluralDns: true,
 			Subdomain: wk.Subdomain,
 		},
+		Context: setup.Context,
 	}
 }
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -18,9 +18,18 @@ type Gcp struct {
 	ApplicationCredentials string `json:"application_credentials"`
 }
 
+type Azure struct {
+	TenantId       string `json:"tenant_id"`
+	ClientId       string `json:"client_id"`
+	ClientSecret   string `json:"client_secret"`
+	StorageAccount string `json:"storage_account"`
+	SubscriptionId string `json:"subscription_id"`
+}
+
 type Credentials struct {
-	Aws *Aws `json:"aws"`
-	Gcp *Gcp `json:"gcp"`
+	Aws   *Aws   `json:"aws"`
+	Gcp   *Gcp   `json:"gcp"`
+	Azure *Azure `json:"azure"`
 }
 
 type User struct {
@@ -46,4 +55,5 @@ type SetupRequest struct {
 	SshPublicKey  string       `json:"ssh_public_key"`
 	SshPrivateKey string       `json:"ssh_private_key"`
 	IsDemo        bool         `json:"is_demo"`
+	Context       map[string]interface{}
 }

--- a/start-session.sh
+++ b/start-session.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
 session="workspace"
+
+# ensure necessary env vars are populated
+if [ -f ~/.env ]; then
+  source ~/.env
+fi
+
 tmux start
 tmux has-session -t $session 2>/dev/null
 


### PR DESCRIPTION
## Summary

It looks like the only effective way to provide local creds is via env vars.  It's a little roundabout since the terminal session needs the env vars not the server proc, so add a .env file and source it at terminal mount


## Test Plan
will need to end-to-end test this once available


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.