### PR TITLE
Display upstream sha when git out of sync

### DIFF
--- a/cmd/plural/deploy.go
+++ b/cmd/plural/deploy.go
@@ -99,14 +99,14 @@ func (p *Plural) build(c *cli.Context) error {
 	if err := CheckGitCrypt(c); err != nil {
 		return errors.ErrorWrap(errNoGit, "Failed to scan your repo for secrets to encrypt them")
 	}
-	changed, err := git.HasUpstreamChanges()
+	changed, sha, err := git.HasUpstreamChanges()
 	if err != nil {
 		return errors.ErrorWrap(errNoGit, "Failed to get git information")
 	}
 
 	force := c.Bool("force")
 	if !changed && !force {
-		return errors.ErrorWrap(errRemoteDiff, "Local Changes out of Sync")
+		return errors.ErrorWrap(errRemoteDiff, fmt.Sprintf("Expecting HEAD at commit=%s", sha))
 	}
 
 	if c.IsSet("only") {

--- a/pkg/utils/git/repo.go
+++ b/pkg/utils/git/repo.go
@@ -36,20 +36,20 @@ func CurrentBranch() (b string, err error) {
 	return
 }
 
-func HasUpstreamChanges() (bool, error) {
+func HasUpstreamChanges() (bool, string, error) {
 	repo, err := Repo()
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	ref, err := repo.Head()
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	res, err := GitRaw("ls-remote", "origin", "-h", fmt.Sprintf("refs/heads/%s", ref.Name().Short()))
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(res))
@@ -62,7 +62,7 @@ func HasUpstreamChanges() (bool, error) {
 		}
 	}
 
-	return remote == ref.Hash().String(), nil
+	return remote == ref.Hash().String(), remote, nil
 }
 
 func Init() (string, error) {


### PR DESCRIPTION
## Summary

We currently still have a somewhat opaque error when you're local and remote repo is out-of-sync.  Showing the expected sha should help a bit.

## Test Plan
compiles


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.