### PR TITLE
Fix oidc redirect uri bug

### DIFF
--- a/pkg/api/installations.go
+++ b/pkg/api/installations.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/pluralsh/gqlclient"
 	"github.com/pluralsh/gqlclient/pkg/utils"
 )
@@ -131,15 +133,14 @@ func (client *client) OIDCProvider(id string, attributes *OidcProviderAttributes
 		})
 	}
 
+	redirectUris := convertRedirectUris(attributes.RedirectUris)
 	_, err := client.pluralClient.UpsertOidcProvider(client.ctx, id, gqlclient.OidcAttributes{
 		AuthMethod:   gqlclient.OidcAuthMethod(attributes.AuthMethod),
 		Bindings:     bindings,
-		RedirectUris: convertRedirectUris(attributes.RedirectUris),
+		RedirectUris: redirectUris,
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	fmt.Printf("%+v", redirectUris)
+	return err
 }
 
 func (client *client) ResetInstallations() (int, error) {
@@ -152,9 +153,9 @@ func (client *client) ResetInstallations() (int, error) {
 }
 
 func convertRedirectUris(uris []string) []*string {
-	res := make([]*string, 0)
-	for _, s := range uris {
-		res = append(res, &s)
+	res := make([]*string, len(uris))
+	for i := range uris {
+		res[i] = &uris[i]
 	}
 	return res
 }

--- a/pkg/bundle/oidc.go
+++ b/pkg/bundle/oidc.go
@@ -70,6 +70,8 @@ func mergeOidcAttributes(inst *api.Installation, attributes *api.OidcProviderAtt
 		}
 	}
 	attributes.Bindings = bindings
+	fmt.Printf("%+v", attributes)
+
 }
 
 func formatRedirectUris(settings *api.OIDCSettings, ctx map[string]interface{}) ([]string, error) {


### PR DESCRIPTION
## Summary

Apparently range uses the same address on each iteration, so if we use its reference, we'll just populate the array with the same value

## Test Plan
verified locally


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.