### PR TITLE
Add ability to only deploy app + dependencies

### DIFF
--- a/cmd/plural/dependencies.go
+++ b/cmd/plural/dependencies.go
@@ -11,7 +11,7 @@ func (p *Plural) topsort(c *cli.Context) error {
 	p.InitPluralClient()
 	installations, _ := p.GetInstallations()
 	repoName := c.Args().Get(0)
-	sorted, err := wkspace.Dependencies(p.Client, repoName, installations)
+	sorted, err := wkspace.UntilRepo(p.Client, repoName, installations)
 	if err != nil {
 		return err
 	}
@@ -19,5 +19,19 @@ func (p *Plural) topsort(c *cli.Context) error {
 	for _, inst := range sorted {
 		fmt.Println(inst.Repository.Name)
 	}
+	return nil
+}
+
+func (p *Plural) dependencies(c *cli.Context) error {
+	repo := c.Args().Get(0)
+	deps, err := wkspace.Dependencies(repo)
+	if err != nil {
+		return err
+	}
+
+	for _, dep := range deps {
+		fmt.Println(dep)
+	}
+
 	return nil
 }

--- a/cmd/plural/plural.go
+++ b/cmd/plural/plural.go
@@ -93,6 +93,10 @@ func (p *Plural) getCommands() []cli.Command {
 					Name:  "commit",
 					Usage: "commits your changes with this message",
 				},
+				cli.StringFlag{
+					Name:  "from",
+					Usage: "deploys only this application and its dependencies",
+				},
 				cli.BoolFlag{
 					Name:  "force",
 					Usage: "use force push when pushing to git",
@@ -164,6 +168,13 @@ func (p *Plural) getCommands() []cli.Command {
 			Aliases:  []string{"d"},
 			Usage:    "renders a dependency-inferred topological sort of the installations in a workspace",
 			Action:   p.topsort,
+			Category: "Workspace",
+		},
+		{
+			Name:     "dependencies",
+			Aliases:  []string{"deps"},
+			Usage:    "prints ordered dependencies for a repo in your workspace",
+			Action:   p.dependencies,
 			Category: "Workspace",
 		},
 		{

--- a/cmd/plural/plural_test.go
+++ b/cmd/plural/plural_test.go
@@ -68,6 +68,7 @@ COMMANDS:
    Workspace:
      validate, v         validates your workspace
      topsort, d          renders a dependency-inferred topological sort of the installations in a workspace
+     dependencies, deps  prints ordered dependencies for a repo in your workspace
      serve               launch the server
      shell               manages your cloud shell
      workspace, wkspace  Commands for managing installations in your workspace

--- a/pkg/utils/containers/stack.go
+++ b/pkg/utils/containers/stack.go
@@ -1,0 +1,38 @@
+package containers
+
+import "fmt"
+
+type Stack[T any] struct {
+	items []T
+	pos   int
+}
+
+func NewStack[T any]() *Stack[T] {
+	return &Stack[T]{items: make([]T, 0), pos: 0}
+}
+
+func (stack *Stack[T]) Len() int {
+	return stack.pos
+}
+
+func (stack *Stack[T]) Push(value T) {
+	pos := stack.pos
+	if pos >= len(stack.items) {
+		stack.items = append(stack.items, value)
+	} else {
+		stack.items[pos] = value
+	}
+	stack.pos = pos + 1
+}
+
+func (stack *Stack[T]) Pop() (res T, err error) {
+	pos := stack.pos
+	if pos == 0 {
+		err = fmt.Errorf("stack is empty")
+		return
+	}
+
+	res = stack.items[pos-1]
+	stack.pos = pos - 1
+	return
+}

--- a/pkg/utils/containers/utils.go
+++ b/pkg/utils/containers/utils.go
@@ -1,0 +1,63 @@
+package containers
+
+func Reverse[T any](arr []T) []T {
+	length := len(arr)
+	res := make([]T, length)
+
+	for ind, val := range arr {
+		res[length-ind-1] = val
+	}
+
+	return res
+}
+
+func Map[T any, V any](arr []T, f func(T) V) []V {
+	res := make([]V, len(arr))
+	for ind, val := range arr {
+		res[ind] = f(val)
+	}
+
+	return res
+}
+
+func Filter[T any](arr []T, f func(T) bool) []T {
+	res := make([]T, 0)
+	for _, v := range arr {
+		if f(v) {
+			res = append(res, v)
+		}
+	}
+
+	return res
+}
+
+func DFS[T comparable](initial T, neighbors func(T) ([]T, error)) ([]T, error) {
+	res := make([]T, 0)
+	seen := map[T]bool{}
+	s := NewStack[T]()
+	s.Push(initial)
+
+	for s.Len() > 0 {
+		r, err := s.Pop()
+		if err != nil {
+			return res, err
+		}
+
+		if _, ok := seen[r]; ok {
+			continue
+		}
+
+		seen[r] = true
+		res = append(res, r)
+		nebs, err := neighbors(r)
+		if err != nil {
+			return res, err
+		}
+
+		for _, neb := range nebs {
+			s.Push(neb)
+		}
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
## Summary

This pr introduces two things:

* `plural dependencies REPO` - lists deps for a repo in topo order
* `--from` flag for `plural deploy` - this will deploy only an app and its deps in appropriate order

I also added a fair number of go generics utils that were helpful here and likely in the future.  We should probably create a separate lib for those soon.


## Test Plan
tested locally


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.