### PR TITLE
Add confirmation dialog when using existing workspace file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,16 +6,13 @@ linters:
   disable-all: true
   enable:
   # default linters
-  - deadcode
   - errcheck
   - gosimple
   - govet
   - ineffassign
   - staticcheck
-  # - structcheck # disabled due to Go 1.18
   - typecheck
   - unused
-  - varcheck
 
   # additional linters
   - errorlint
@@ -27,7 +24,4 @@ linters:
   - importas
   - goconst
   - gocritic
-  # - godox
-  # - gosec
   - misspell
-  # - predeclared

--- a/cmd/plural/api.go
+++ b/cmd/plural/api.go
@@ -81,12 +81,12 @@ func (p *Plural) handleInstallations(c *cli.Context) error {
 		return err
 	}
 
-	installations = containers.Filter[*api.Installation](installations, func(v *api.Installation) bool {
+	installations = containers.Filter(installations, func(v *api.Installation) bool {
 		return v.Repository != nil
 	})
 
 	headers := []string{"Repository", "Repository Id", "Publisher"}
-	return utils.PrintTable[*api.Installation](installations, headers, func(inst *api.Installation) ([]string, error) {
+	return utils.PrintTable(installations, headers, func(inst *api.Installation) ([]string, error) {
 		repo := inst.Repository
 		publisherName := ""
 		if repo.Publisher != nil {
@@ -104,7 +104,7 @@ func (p *Plural) handleCharts(c *cli.Context) error {
 	}
 
 	headers := []string{"Id", "Name", "Description", "Latest Version"}
-	return utils.PrintTable[*api.Chart](charts, headers, func(c *api.Chart) ([]string, error) {
+	return utils.PrintTable(charts, headers, func(c *api.Chart) ([]string, error) {
 		return []string{c.Id, c.Name, c.Description, c.LatestVersion}, nil
 	})
 }
@@ -117,7 +117,7 @@ func (p *Plural) handleTerraforma(c *cli.Context) error {
 	}
 
 	headers := []string{"Id", "Name", "Description"}
-	return utils.PrintTable[*api.Terraform](tfs, headers, func(tf *api.Terraform) ([]string, error) {
+	return utils.PrintTable(tfs, headers, func(tf *api.Terraform) ([]string, error) {
 		return []string{tf.Id, tf.Name, tf.Description}, nil
 	})
 }
@@ -131,7 +131,7 @@ func (p *Plural) handleVersions(c *cli.Context) error {
 	}
 
 	headers := []string{"Id", "Version"}
-	return utils.PrintTable[*api.Version](versions, headers, func(v *api.Version) ([]string, error) {
+	return utils.PrintTable(versions, headers, func(v *api.Version) ([]string, error) {
 		return []string{v.Id, v.Version}, nil
 	})
 }
@@ -143,7 +143,7 @@ func (p *Plural) handleChartInstallations(c *cli.Context) error {
 		return err
 	}
 
-	cis := containers.Filter[*api.ChartInstallation](chartInstallations, func(ci *api.ChartInstallation) bool {
+	cis := containers.Filter(chartInstallations, func(ci *api.ChartInstallation) bool {
 		return ci.Chart != nil && ci.Version != nil
 	})
 
@@ -151,7 +151,7 @@ func (p *Plural) handleChartInstallations(c *cli.Context) error {
 		return []string{ci.Id, ci.Chart.Id, ci.Chart.Name, ci.Version.Version}, nil
 	}
 	headers := []string{"Id", "Chart Id", "Chart Name", "Version"}
-	return utils.PrintTable[*api.ChartInstallation](cis, headers, row)
+	return utils.PrintTable(cis, headers, row)
 }
 
 func (p *Plural) handleTerraformInstallations(c *cli.Context) error {
@@ -161,12 +161,12 @@ func (p *Plural) handleTerraformInstallations(c *cli.Context) error {
 		return err
 	}
 
-	tis := containers.Filter[*api.TerraformInstallation](terraformInstallations, func(ti *api.TerraformInstallation) bool {
+	tis := containers.Filter(terraformInstallations, func(ti *api.TerraformInstallation) bool {
 		return ti != nil
 	})
 
 	headers := []string{"Id", "Terraform Id", "Name"}
-	return utils.PrintTable[*api.TerraformInstallation](tis, headers, func(ti *api.TerraformInstallation) ([]string, error) {
+	return utils.PrintTable(tis, headers, func(ti *api.TerraformInstallation) ([]string, error) {
 		tf := ti.Terraform
 		return []string{ti.Id, tf.Id, tf.Name}, nil
 	})
@@ -180,7 +180,7 @@ func (p *Plural) handleArtifacts(c *cli.Context) error {
 	}
 
 	headers := []string{"Id", "Name", "Platform", "Blob", "Sha"}
-	return utils.PrintTable[api.Artifact](artifacts, headers, func(art api.Artifact) ([]string, error) {
+	return utils.PrintTable(artifacts, headers, func(art api.Artifact) ([]string, error) {
 		return []string{art.Id, art.Name, art.Platform, art.Blob, art.Sha}, nil
 	})
 }

--- a/cmd/plural/bundle.go
+++ b/cmd/plural/bundle.go
@@ -77,7 +77,7 @@ func (p *Plural) bundleList(c *cli.Context) error {
 	}
 
 	headers := []string{"Name", "Description", "Provider", "Install Command"}
-	return utils.PrintTable[*api.Recipe](recipes, headers, func(recipe *api.Recipe) ([]string, error) {
+	return utils.PrintTable(recipes, headers, func(recipe *api.Recipe) ([]string, error) {
 		return []string{recipe.Name, recipe.Description, recipe.Provider, fmt.Sprintf("plural bundle install %s %s", repo, recipe.Name)}, nil
 	})
 }
@@ -111,7 +111,7 @@ func (p *Plural) stackList(c *cli.Context) (err error) {
 	}
 
 	headers := []string{"Name", "Description", "Featured"}
-	return utils.PrintTable[*api.Stack](stacks, headers, func(s *api.Stack) ([]string, error) {
+	return utils.PrintTable(stacks, headers, func(s *api.Stack) ([]string, error) {
 		return []string{s.Name, s.Description, fmt.Sprintf("%v", s.Featured)}, nil
 	})
 }

--- a/cmd/plural/bundle_test.go
+++ b/cmd/plural/bundle_test.go
@@ -1,7 +1,6 @@
 package main_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -45,7 +44,7 @@ func TestBundleList(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			currentDir, err := os.Getwd()
 			assert.NoError(t, err)
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer func(path, currentDir string) {
 				_ = os.RemoveAll(path)
@@ -129,7 +128,7 @@ func TestBundleInstall(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 			err = os.Chdir(dir)

--- a/cmd/plural/config.go
+++ b/cmd/plural/config.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/pluralsh/plural/pkg/config"
@@ -76,7 +76,7 @@ func handleRead(c *cli.Context) error {
 }
 
 func handleConfigImport(c *cli.Context) error {
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/cmd/plural/config.go
+++ b/cmd/plural/config.go
@@ -100,7 +100,7 @@ func listProfiles(c *cli.Context) error {
 	}
 
 	headers := []string{"Name", "Email", "Endpoint"}
-	return utils.PrintTable[*config.VersionedConfig](profiles, headers, func(profile *config.VersionedConfig) ([]string, error) {
+	return utils.PrintTable(profiles, headers, func(profile *config.VersionedConfig) ([]string, error) {
 		return []string{profile.Metadata.Name, profile.Spec.Email, profile.Spec.BaseUrl()}, nil
 	})
 }

--- a/cmd/plural/config_test.go
+++ b/cmd/plural/config_test.go
@@ -3,7 +3,6 @@ package main_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -37,7 +36,7 @@ func TestPluralConfigCommand(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 

--- a/cmd/plural/crypto.go
+++ b/cmd/plural/crypto.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -135,7 +134,7 @@ func (p *Plural) cryptoCommands() []cli.Command {
 }
 
 func handleEncrypt(c *cli.Context) error {
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if bytes.HasPrefix(data, prefix) {
 		_, err := os.Stdout.Write(data)
 		if err != nil {
@@ -184,7 +183,7 @@ func handleDecrypt(c *cli.Context) error {
 		file = os.Stdin
 	}
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return err
 	}
@@ -319,7 +318,7 @@ func exportKey(c *cli.Context) error {
 }
 
 func importKey(c *cli.Context) error {
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}
@@ -374,11 +373,11 @@ func handleKeygen(c *cli.Context) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(path, filename), []byte(priv), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(path, filename), []byte(priv), 0600); err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(path, filename+".pub"), []byte(pub), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(path, filename+".pub"), []byte(pub), 0644); err != nil {
 		return err
 	}
 

--- a/cmd/plural/crypto_test.go
+++ b/cmd/plural/crypto_test.go
@@ -2,7 +2,6 @@ package main_test
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -40,7 +39,7 @@ func TestSetupKeys(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer func(path string) {
 				_ = os.RemoveAll(path)
@@ -120,7 +119,7 @@ func TestShare(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer func(path string) {
 				_ = os.RemoveAll(path)
@@ -181,7 +180,7 @@ func TestRecover(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 
@@ -196,7 +195,7 @@ func TestRecover(t *testing.T) {
 			kube := mocks.NewKube(t)
 
 			if test.keyContent != "" {
-				err := ioutil.WriteFile(path.Join(dir, ".plural", "key"), []byte(test.keyContent), 0644)
+				err := os.WriteFile(path.Join(dir, ".plural", "key"), []byte(test.keyContent), 0644)
 				assert.NoError(t, err)
 			}
 
@@ -231,7 +230,7 @@ func TestCheckGitCrypt(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer func(path string) {
 				_ = os.RemoveAll(path)
@@ -241,7 +240,7 @@ func TestCheckGitCrypt(t *testing.T) {
 			defaultConfig := pluraltest.GenDefaultConfig()
 			err = defaultConfig.Save(config.ConfigName)
 			assert.NoError(t, err)
-			err = ioutil.WriteFile(path.Join(dir, ".plural", "key"), []byte("key: abc"), 0644)
+			err = os.WriteFile(path.Join(dir, ".plural", "key"), []byte("key: abc"), 0644)
 			assert.NoError(t, err)
 
 			err = os.Chdir(dir)

--- a/cmd/plural/deploy_test.go
+++ b/cmd/plural/deploy_test.go
@@ -1,7 +1,6 @@
 package main_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -44,8 +43,7 @@ func TestBuildContext(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 
@@ -129,7 +127,7 @@ func TestValidate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 

--- a/cmd/plural/init.go
+++ b/cmd/plural/init.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -176,7 +175,7 @@ func handleImport(c *cli.Context) error {
 		return err
 	}
 
-	data, err := ioutil.ReadFile(pathing.SanitizeFilepath(filepath.Join(dir, "key")))
+	data, err := os.ReadFile(pathing.SanitizeFilepath(filepath.Join(dir, "key")))
 	if err != nil {
 		return err
 	}

--- a/cmd/plural/init.go
+++ b/cmd/plural/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/pluralsh/plural/pkg/api"
 	"github.com/pluralsh/plural/pkg/config"
 	"github.com/pluralsh/plural/pkg/crypto"
+	"github.com/pluralsh/plural/pkg/manifest"
 	"github.com/pluralsh/plural/pkg/provider"
 	"github.com/pluralsh/plural/pkg/scm"
 	"github.com/pluralsh/plural/pkg/server"
@@ -21,15 +23,21 @@ import (
 )
 
 func handleInit(c *cli.Context) error {
-	git, err := wkspace.Preflight()
 	gitCreated := false
 	repo := ""
+
+	git, err := wkspace.Preflight()
 	if err != nil && git {
 		return err
 	}
 
 	if err := handleLogin(c); err != nil {
 		return err
+	}
+
+	if _, err := os.Stat(manifest.ProjectManifestPath()); err == nil && git && !affirm("This repository's workspace.yaml already exists. Would you like to use it?") {
+		fmt.Println("Run `plural init` from empty repository or outside any in order to start from scratch.")
+		return nil
 	}
 
 	prov, err := runPreflights()

--- a/cmd/plural/ops.go
+++ b/cmd/plural/ops.go
@@ -52,7 +52,7 @@ func (p *Plural) handleListNodes(cli *cli.Context) error {
 	}
 
 	headers := []string{"Name", "CPU", "Memory", "Region", "Zone"}
-	return utils.PrintTable[v1.Node](nodes.Items, headers, func(node v1.Node) ([]string, error) {
+	return utils.PrintTable(nodes.Items, headers, func(node v1.Node) ([]string, error) {
 		status := node.Status
 		labels := node.ObjectMeta.Labels
 		cpu, mem := status.Capacity["cpu"], status.Capacity["memory"]
@@ -69,7 +69,7 @@ func (p *Plural) handleListNodes(cli *cli.Context) error {
 func getProvider() (provider.Provider, error) {
 	_, found := utils.ProjectRoot()
 	if !found {
-		return nil, fmt.Errorf("Project not initialized, run `plural init` to set up a workspace")
+		return nil, fmt.Errorf("project not initialized, run `plural init` to set up a workspace")
 	}
 
 	return provider.GetProvider()

--- a/cmd/plural/ops_test.go
+++ b/cmd/plural/ops_test.go
@@ -1,7 +1,6 @@
 package main_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -97,7 +96,7 @@ func TestTerminate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 			err = os.Chdir(dir)

--- a/cmd/plural/push.go
+++ b/cmd/plural/push.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -164,7 +163,7 @@ func tmpValuesFile(path string, conf *config.Config) (f *os.File, err error) {
 		return
 	}
 
-	f, err = ioutil.TempFile("", "values.yaml")
+	f, err = os.CreateTemp("", "values.yaml")
 	if err != nil {
 		return
 	}
@@ -180,7 +179,7 @@ func tmpValuesFile(path string, conf *config.Config) (f *os.File, err error) {
 func (p *Plural) handleRecipeUpload(c *cli.Context) error {
 	p.InitPluralClient()
 	fullPath, _ := filepath.Abs(c.Args().Get(0))
-	contents, err := ioutil.ReadFile(fullPath)
+	contents, err := os.ReadFile(fullPath)
 	if err != nil {
 		return err
 	}
@@ -197,7 +196,7 @@ func (p *Plural) handleRecipeUpload(c *cli.Context) error {
 func (p *Plural) handleArtifact(c *cli.Context) error {
 	p.InitPluralClient()
 	fullPath, _ := filepath.Abs(c.Args().Get(0))
-	contents, err := ioutil.ReadFile(fullPath)
+	contents, err := os.ReadFile(fullPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/plural/template.go
+++ b/cmd/plural/template.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/pluralsh/plural-operator/apis/platform/v1alpha1"
@@ -20,7 +20,7 @@ func testTemplate(c *cli.Context) error {
 	client := api.NewClient()
 	installations, _ := client.GetInstallations()
 	repoName := c.Args().Get(0)
-	testTemplate, err := ioutil.ReadAll(os.Stdin)
+	testTemplate, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func formatDashboard(c *cli.Context) error {
 
 	dashboard := v1alpha1.Dashboard{}
 	grafana := GrafanaDashboard{}
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/cmd/plural/utils.go
+++ b/cmd/plural/utils.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -106,11 +105,11 @@ func replaceVals(path string, val string) error {
 
 	content := strings.Join(result, "\n")
 
-	return ioutil.WriteFile(path, []byte(content), 0644)
+	return os.WriteFile(path, []byte(content), 0644)
 }
 
 func readHelmYaml(path string, result *map[string]interface{}) error {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -124,5 +123,5 @@ func writeHelmYaml(path string, vals map[string]interface{}) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, io, 0644)
+	return os.WriteFile(path, io, 0644)
 }

--- a/cmd/plural/version.go
+++ b/cmd/plural/version.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime"
 	"strings"
@@ -30,7 +30,7 @@ func getLatestVersion() (res string, err error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}

--- a/pkg/bundle/configuration_test.go
+++ b/pkg/bundle/configuration_test.go
@@ -2,7 +2,6 @@ package bundle_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -129,7 +128,7 @@ func TestConfigureEnvVariables(t *testing.T) {
 				}
 			}(test.envVars)
 
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 

--- a/pkg/bundle/tests/git.go
+++ b/pkg/bundle/tests/git.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -18,7 +17,7 @@ func testGit(ctx *manifest.Context, test *api.RecipeTest) error {
 		return err
 	}
 	url := args["url"].Val.(string)
-	dir, err := ioutil.TempDir("", "repo")
+	dir, err := os.MkdirTemp("", "repo")
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -72,7 +71,7 @@ func Profile(name string) error {
 func Profiles() ([]*VersionedConfig, error) {
 	folder, _ := os.UserHomeDir()
 	confDir := path.Join(folder, pluralDir)
-	files, err := ioutil.ReadDir(confDir)
+	files, err := os.ReadDir(confDir)
 	confs := []*VersionedConfig{}
 	if err != nil {
 		return confs, err
@@ -80,7 +79,7 @@ func Profiles() ([]*VersionedConfig, error) {
 
 	for _, f := range files {
 		if !strings.HasSuffix(f.Name(), ConfigName) && strings.HasSuffix(f.Name(), ".yml") {
-			contents, err := ioutil.ReadFile(path.Join(confDir, f.Name()))
+			contents, err := os.ReadFile(path.Join(confDir, f.Name()))
 			if err != nil {
 				return confs, err
 			}
@@ -97,7 +96,7 @@ func Profiles() ([]*VersionedConfig, error) {
 }
 
 func Import(file string) (conf Config) {
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return
 	}
@@ -174,7 +173,7 @@ func (c *Config) Save(filename string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path.Join(folder, pluralDir, filename), io, 0644)
+	return os.WriteFile(path.Join(folder, pluralDir, filename), io, 0644)
 }
 
 func (c *Config) Flush() error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestExists(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 
@@ -65,7 +64,7 @@ func TestRead(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 
@@ -109,7 +108,7 @@ func TestProfiles(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 
@@ -173,7 +172,7 @@ func TestAmend(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 

--- a/pkg/crypto/age.go
+++ b/pkg/crypto/age.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -84,7 +83,7 @@ func BuildAgeProvider() (prov *AgeProvider, err error) {
 	}
 
 	prov = &AgeProvider{Identity: ident}
-	contents, err := ioutil.ReadFile(pathing.SanitizeFilepath(filepath.Join(cryptPath(), "key")))
+	contents, err := os.ReadFile(pathing.SanitizeFilepath(filepath.Join(cryptPath(), "key")))
 	if err != nil {
 		return
 	}
@@ -198,7 +197,7 @@ func (age *Age) WriteKeyFile(path string, keydata []byte) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(path, encrypted, 0644); err != nil {
+	if err := os.WriteFile(path, encrypted, 0644); err != nil {
 		return err
 	}
 	// always flush current age config after writing key to preserve state
@@ -211,7 +210,7 @@ func (age *Age) Flush() error {
 		return err
 	}
 
-	return ioutil.WriteFile(pathing.SanitizeFilepath(filepath.Join(cryptPath(), identityFile)), contents, 0644)
+	return os.WriteFile(pathing.SanitizeFilepath(filepath.Join(cryptPath(), identityFile)), contents, 0644)
 }
 
 func SetupIdentity(client api.Client, name string) error {
@@ -229,7 +228,7 @@ func setupAgeConfig() (*Age, error) {
 
 	if utils.Exists(path) {
 		age := &Age{}
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return age, err
 		}
@@ -243,7 +242,7 @@ func setupAgeConfig() (*Age, error) {
 		return nil, err
 	}
 
-	if err := ioutil.WriteFile(pathing.SanitizeFilepath(filepath.Join(base, ".gitignore")), []byte(gitignore), 0644); err != nil {
+	if err := os.WriteFile(pathing.SanitizeFilepath(filepath.Join(base, ".gitignore")), []byte(gitignore), 0644); err != nil {
 		return nil, err
 	}
 
@@ -282,7 +281,7 @@ func identityFromString(contents string) (*age.X25519Identity, error) {
 
 func generateIdentity(path string) (*age.X25519Identity, error) {
 	if utils.Exists(path) {
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/crypto/config.go
+++ b/pkg/crypto/config.go
@@ -1,7 +1,7 @@
 package crypto
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pluralsh/plural/pkg/utils"
@@ -23,7 +23,7 @@ func configPath() string {
 
 func ReadConfig() (conf *Config, err error) {
 	conf = &Config{}
-	contents, err := ioutil.ReadFile(configPath())
+	contents, err := os.ReadFile(configPath())
 	if err != nil {
 		return
 	}

--- a/pkg/crypto/config_test.go
+++ b/pkg/crypto/config_test.go
@@ -1,7 +1,6 @@
 package crypto_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -34,8 +33,7 @@ func TestBuild(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 
@@ -48,13 +46,13 @@ func TestBuild(t *testing.T) {
 			assert.NoError(t, err)
 
 			if test.genConfig {
-				err := ioutil.WriteFile(path.Join(dir, "crypto.yml"), []byte("abc"), 0644)
+				err := os.WriteFile(path.Join(dir, "crypto.yml"), []byte("abc"), 0644)
 				assert.NoError(t, err)
 			}
 
 			err = os.MkdirAll(path.Join(dir, ".plural"), os.ModePerm)
 			assert.NoError(t, err)
-			err = ioutil.WriteFile(path.Join(dir, ".plural", "key"), []byte(test.keyContent), 0644)
+			err = os.WriteFile(path.Join(dir, ".plural", "key"), []byte(test.keyContent), 0644)
 			assert.NoError(t, err)
 
 			provider, err := crypto.Build()

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -66,7 +65,7 @@ type AESKey struct {
 }
 
 func Read(path string) (*AESKey, error) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -137,5 +136,5 @@ func (k *AESKey) Flush() error {
 		return err
 	}
 
-	return ioutil.WriteFile(getKeyPath(), io, 0644)
+	return os.WriteFile(getKeyPath(), io, 0644)
 }

--- a/pkg/crypto/provider.go
+++ b/pkg/crypto/provider.go
@@ -1,8 +1,6 @@
 package crypto
 
-import (
-	"io/ioutil"
-)
+import "os"
 
 type IdentityType string
 
@@ -41,5 +39,5 @@ func Flush(prov Provider) error {
 		return err
 	}
 
-	return ioutil.WriteFile(configPath(), io, 0644)
+	return os.WriteFile(configPath(), io, 0644)
 }

--- a/pkg/diff/builder.go
+++ b/pkg/diff/builder.go
@@ -2,7 +2,6 @@ package diff
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ type Metadata struct {
 
 func GetDiff(path, name string) (*Diff, error) {
 	fullpath := pathing.SanitizeFilepath(filepath.Join(path, name+".hcl"))
-	contents, err := ioutil.ReadFile(fullpath)
+	contents, err := os.ReadFile(fullpath)
 	diff := Diff{}
 	if err != nil {
 		return &diff, nil
@@ -76,7 +75,7 @@ func (e *Diff) Execute() error {
 
 func (e *Diff) IgnoreFile(root string) ([]string, error) {
 	ignorePath := pathing.SanitizeFilepath(filepath.Join(root, e.Metadata.Path, ".pluralignore"))
-	contents, err := ioutil.ReadFile(ignorePath)
+	contents, err := os.ReadFile(ignorePath)
 	if err != nil {
 		return []string{}, err
 	}
@@ -180,7 +179,7 @@ func (d *Diff) Flush(root string) error {
 	}
 
 	path, _ := filepath.Abs(pathing.SanitizeFilepath(filepath.Join(root, d.Metadata.Path, d.Metadata.Name+".hcl")))
-	return ioutil.WriteFile(path, io, 0644)
+	return os.WriteFile(path, io, 0644)
 }
 
 func pluralfile(base, name string) string {

--- a/pkg/executor/execution.go
+++ b/pkg/executor/execution.go
@@ -2,7 +2,7 @@ package executor
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -29,12 +29,12 @@ const (
 
 func Ignore(root string) error {
 	ignoreFile := pathing.SanitizeFilepath(filepath.Join(root, ".pluralignore"))
-	return ioutil.WriteFile(ignoreFile, []byte(pluralIgnore), 0644)
+	return os.WriteFile(ignoreFile, []byte(pluralIgnore), 0644)
 }
 
 func GetExecution(path, name string) (*Execution, error) {
 	fullpath := pathing.SanitizeFilepath(filepath.Join(path, name+".hcl"))
-	contents, err := ioutil.ReadFile(fullpath)
+	contents, err := os.ReadFile(fullpath)
 	ex := Execution{}
 	if err != nil {
 		return &ex, err
@@ -84,7 +84,7 @@ func (e *Execution) Execute(verbose bool) error {
 
 func (e *Execution) IgnoreFile(root string) ([]string, error) {
 	ignorePath := pathing.SanitizeFilepath(filepath.Join(root, e.Metadata.Path, ".pluralignore"))
-	contents, err := ioutil.ReadFile(ignorePath)
+	contents, err := os.ReadFile(ignorePath)
 	if err != nil {
 		return []string{}, err
 	}
@@ -155,7 +155,7 @@ func (e *Execution) Flush(root string) error {
 	}
 
 	path, _ := filepath.Abs(pathing.SanitizeFilepath(filepath.Join(root, e.Metadata.Path, e.Metadata.Name+".hcl")))
-	return ioutil.WriteFile(path, io, 0644)
+	return os.WriteFile(path, io, 0644)
 }
 
 func pluralfile(base, name string) string {

--- a/pkg/helm/push.go
+++ b/pkg/helm/push.go
@@ -3,7 +3,6 @@ package helm
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -35,7 +34,7 @@ func Push(chartName, repoUrl string) error {
 		return err
 	}
 
-	tmp, err := ioutil.TempDir("", "helm-push-")
+	tmp, err := os.MkdirTemp("", "helm-push-")
 	if err != nil {
 		return err
 	}
@@ -57,7 +56,7 @@ func Push(chartName, repoUrl string) error {
 	}(resp.Body)
 
 	if resp.StatusCode != 201 && resp.StatusCode != 202 {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/manifest/context.go
+++ b/pkg/manifest/context.go
@@ -2,7 +2,7 @@ package manifest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pluralsh/plural/pkg/api"
@@ -55,7 +55,7 @@ func BuildContext(path string, insts []*api.Installation) error {
 }
 
 func ReadContext(path string) (c *Context, err error) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}
@@ -133,7 +133,7 @@ func (c *Context) Write(path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, io, 0644)
+	return os.WriteFile(path, io, 0644)
 }
 
 func (c *Context) ContainsString(str, msg, ignoreRepo, ignoreKey string) error {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -2,7 +2,7 @@ package manifest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -49,7 +49,7 @@ func (pMan *ProjectManifest) Write(path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, io, 0644)
+	return os.WriteFile(path, io, 0644)
 }
 
 func FetchProject() (*ProjectManifest, error) {
@@ -58,7 +58,7 @@ func FetchProject() (*ProjectManifest, error) {
 }
 
 func ReadProject(path string) (man *ProjectManifest, err error) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		err = fmt.Errorf("could not find workspace.yaml file, you might need to run `plural init`")
 		return
@@ -89,11 +89,11 @@ func (man *Manifest) Write(path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, io, 0644)
+	return os.WriteFile(path, io, 0644)
 }
 
 func Read(path string) (man *Manifest, err error) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}

--- a/pkg/output/types.go
+++ b/pkg/output/types.go
@@ -1,7 +1,7 @@
 package output
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/pluralsh/plural/pkg/manifest"
 	"gopkg.in/yaml.v2"
@@ -35,11 +35,11 @@ func (out *Output) Save(app, path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, io, 0644)
+	return os.WriteFile(path, io, 0644)
 }
 
 func Read(path string) (out *Output, err error) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}

--- a/pkg/pluralfile/artifact.go
+++ b/pkg/pluralfile/artifact.go
@@ -2,7 +2,6 @@ package pluralfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -47,7 +46,7 @@ func mkSha(file string) (sha string, err error) {
 		return
 	}
 
-	contents, err := ioutil.ReadFile(fullPath)
+	contents, err := os.ReadFile(fullPath)
 	if err != nil {
 		return
 	}

--- a/pkg/pluralfile/attrs.go
+++ b/pkg/pluralfile/attrs.go
@@ -2,7 +2,7 @@ package pluralfile
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pluralsh/plural/pkg/api"
@@ -24,7 +24,7 @@ func (a *RepoAttrs) Key() string {
 
 func (a *RepoAttrs) Push(repo string, sha string) (string, error) {
 	fullPath, _ := filepath.Abs(a.File)
-	contents, err := ioutil.ReadFile(fullPath)
+	contents, err := os.ReadFile(fullPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/pluralfile/lock.go
+++ b/pkg/pluralfile/lock.go
@@ -2,7 +2,7 @@ package pluralfile
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pluralsh/plural/pkg/api"
@@ -74,7 +74,7 @@ func Lock(path string) (*Lockfile, error) {
 	conf := config.Read()
 	lock := lock()
 	lockfile := lockPath(path, conf.LockProfile)
-	content, err := ioutil.ReadFile(lockfile)
+	content, err := os.ReadFile(lockfile)
 	if err != nil {
 		return lock, nil
 	}
@@ -99,7 +99,7 @@ func (lock *Lockfile) Flush(path string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(lockPath(path, conf.LockProfile), io, 0644)
+	return os.WriteFile(lockPath(path, conf.LockProfile), io, 0644)
 }
 
 func (lock *Lockfile) getSha(name ComponentName, key string) string {

--- a/pkg/pluralfile/stack.go
+++ b/pkg/pluralfile/stack.go
@@ -1,7 +1,7 @@
 package pluralfile
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pluralsh/plural/pkg/api"
@@ -29,7 +29,7 @@ func (a *Stack) Push(repo string, sha string) (string, error) {
 	}
 
 	fullPath, _ := filepath.Abs(a.File)
-	contents, err := ioutil.ReadFile(fullPath)
+	contents, err := os.ReadFile(fullPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/provider/equinix.go
+++ b/pkg/provider/equinix.go
@@ -5,9 +5,9 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -150,12 +150,12 @@ func (equinix *EQUINIXProvider) KubeConfig() error {
 
 	usr, _ := user.Current()
 
-	input, err := ioutil.ReadFile(pathing.SanitizeFilepath(filepath.Join(usr.HomeDir, ".kube/config")))
+	input, err := os.ReadFile(pathing.SanitizeFilepath(filepath.Join(usr.HomeDir, ".kube/config")))
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(pathing.SanitizeFilepath(filepath.Join(usr.HomeDir, ".kube/config-plural-backup")), input, 0644)
+	err = os.WriteFile(pathing.SanitizeFilepath(filepath.Join(usr.HomeDir, ".kube/config-plural-backup")), input, 0644)
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func (equinix *EQUINIXProvider) KubeConfig() error {
 		return err
 	}
 
-	return ioutil.WriteFile(pathing.SanitizeFilepath(filepath.Join(usr.HomeDir, ".kube/config")), output, 0644)
+	return os.WriteFile(pathing.SanitizeFilepath(filepath.Join(usr.HomeDir, ".kube/config")), output, 0644)
 }
 
 func (equinix *EQUINIXProvider) Name() string {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -99,7 +99,7 @@ func FromManifest(man *manifest.ProjectManifest) (Provider, error) {
 	case KIND:
 		return kindFromManifest(man)
 	default:
-		return nil, fmt.Errorf("Invalid provider name: %s", man.Provider)
+		return nil, fmt.Errorf("invalid provider name: %s", man.Provider)
 	}
 }
 
@@ -117,7 +117,7 @@ func New(provider string) (Provider, error) {
 	case KIND:
 		return mkKind(conf)
 	default:
-		return nil, fmt.Errorf("Invalid provider name: %s", provider)
+		return nil, fmt.Errorf("invalid provider name: %s", provider)
 	}
 }
 

--- a/pkg/scaffold/application.go
+++ b/pkg/scaffold/application.go
@@ -1,7 +1,7 @@
 package scaffold
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pluralsh/plural/pkg/output"
@@ -30,7 +30,7 @@ func NewApplications() (*Applications, error) {
 func (apps *Applications) HelmValues(app string) (map[string]interface{}, error) {
 	var res map[string]interface{}
 	path := pathing.SanitizeFilepath(filepath.Join(apps.Root, app, "helm", app, "values.yaml"))
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return res, err
 	}

--- a/pkg/scaffold/crd.go
+++ b/pkg/scaffold/crd.go
@@ -2,8 +2,9 @@ package scaffold
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"github.com/pluralsh/plural/pkg/api"
@@ -34,10 +35,10 @@ func writeCrd(path string, crd *api.Crd) error {
 		return err
 	}
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(pathing.SanitizeFilepath(filepath.Join(path, crd.Name)), contents, 0644)
+	return os.WriteFile(pathing.SanitizeFilepath(filepath.Join(path, crd.Name)), contents, 0644)
 }

--- a/pkg/scaffold/default.go
+++ b/pkg/scaffold/default.go
@@ -1,7 +1,7 @@
 package scaffold
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/hashicorp/hcl"
@@ -12,7 +12,7 @@ import (
 
 func Read(path string) (*Build, error) {
 	fullpath := pathing.SanitizeFilepath(filepath.Join(path, "build.hcl"))
-	contents, err := ioutil.ReadFile(fullpath)
+	contents, err := os.ReadFile(fullpath)
 	build := Build{}
 	if err != nil {
 		return &build, err

--- a/pkg/scaffold/helm.go
+++ b/pkg/scaffold/helm.go
@@ -3,7 +3,6 @@ package scaffold
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -253,7 +252,7 @@ func prevValues(filename string) (map[string]map[string]interface{}, error) {
 		return parsed, nil
 	}
 
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 	if err != nil {
 		return parsed, err
 	}
@@ -278,7 +277,7 @@ func (s *Scaffold) createChart(w *wkspace.Workspace) error {
 	filename := pathing.SanitizeFilepath(filepath.Join(s.Root, ChartfileName))
 
 	if utils.Exists(filename) {
-		content, err := ioutil.ReadFile(filename)
+		content, err := os.ReadFile(filename)
 		if err != nil {
 			return errors.ErrorWrap(err, "Failed to read existing Chart.yaml")
 		}

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -1,7 +1,6 @@
 package scaffold
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -119,7 +118,7 @@ func (b *Build) Flush(root string) error {
 	}
 
 	path, _ := filepath.Abs(pathing.SanitizeFilepath(filepath.Join(root, b.Metadata.Name, "build.hcl")))
-	return ioutil.WriteFile(path, io, 0644)
+	return os.WriteFile(path, io, 0644)
 }
 
 func (s *Scaffold) Execute(wk *wkspace.Workspace, force bool) error {

--- a/pkg/scm/keys.go
+++ b/pkg/scm/keys.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -59,11 +58,11 @@ func saveKeys(pub, priv string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(keys.priv, []byte(priv), 0600); err != nil {
+	if err := os.WriteFile(keys.priv, []byte(priv), 0600); err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(keys.pub, []byte(pub), 0644); err != nil {
+	if err := os.WriteFile(keys.pub, []byte(pub), 0644); err != nil {
 		return err
 	}
 

--- a/pkg/server/configuration_test.go
+++ b/pkg/server/configuration_test.go
@@ -3,7 +3,6 @@ package server_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -34,7 +33,7 @@ func TestGetConfiguration(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 
@@ -44,7 +43,7 @@ func TestGetConfiguration(t *testing.T) {
 			pm := genProjectManifest()
 			io, err := json.Marshal(pm)
 			assert.NoError(t, err)
-			err = ioutil.WriteFile(path.Join(dir, "workspace.yaml"), io, 0644)
+			err = os.WriteFile(path.Join(dir, "workspace.yaml"), io, 0644)
 			assert.NoError(t, err)
 
 			context := manifest.NewContext()

--- a/pkg/server/context_test.go
+++ b/pkg/server/context_test.go
@@ -2,7 +2,6 @@ package server_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -43,9 +42,7 @@ func TestContextConfiguration(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
-			// create temp environment
-			dir, err := ioutil.TempDir("", "config")
+			dir, err := os.MkdirTemp("", "config")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dir)
 

--- a/pkg/server/git.go
+++ b/pkg/server/git.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -32,10 +31,10 @@ func setupGit(setup *SetupRequest) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(pathing.SanitizeFilepath(filepath.Join(p, "id_rsa")), []byte(setup.SshPrivateKey), 0600); err != nil {
+	if err := os.WriteFile(pathing.SanitizeFilepath(filepath.Join(p, "id_rsa")), []byte(setup.SshPrivateKey), 0600); err != nil {
 		return fmt.Errorf("error writing ssh private key: %w", err)
 	}
-	if err := ioutil.WriteFile(pathing.SanitizeFilepath(filepath.Join(p, "id_rsa.pub")), []byte(setup.SshPublicKey), 0644); err != nil {
+	if err := os.WriteFile(pathing.SanitizeFilepath(filepath.Join(p, "id_rsa.pub")), []byte(setup.SshPublicKey), 0644); err != nil {
 		return fmt.Errorf("error writing ssh public key: %w", err)
 	}
 

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -3,7 +3,7 @@ package server
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"text/template"
 
 	"github.com/mitchellh/go-homedir"
@@ -44,7 +44,7 @@ func setupGcp(setup *SetupRequest) error {
 		return fmt.Errorf("error getting the gcp.json path: %w", err)
 	}
 
-	if err := ioutil.WriteFile(f, []byte(setup.Credentials.Gcp.ApplicationCredentials), 0644); err != nil {
+	if err := os.WriteFile(f, []byte(setup.Credentials.Gcp.ApplicationCredentials), 0644); err != nil {
 		return fmt.Errorf("error writing gcp credentials: %w", err)
 	}
 
@@ -79,7 +79,7 @@ func setupAzure(setup *SetupRequest) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(f, out.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(f, out.Bytes(), 0644); err != nil {
 		return fmt.Errorf("error writing azure env file: %w", err)
 	}
 

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -11,12 +10,12 @@ import (
 )
 
 func CopyFile(src, dest string) error {
-	bytesRead, err := ioutil.ReadFile(src)
+	bytesRead, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(dest, bytesRead, 0644)
+	return os.WriteFile(dest, bytesRead, 0644)
 }
 
 func EmptyDirectory(dir string) error {
@@ -58,11 +57,11 @@ func WriteFile(name string, content []byte) error {
 	if err := os.MkdirAll(filepath.Dir(name), 0755); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(name, content, 0644)
+	return os.WriteFile(name, content, 0644)
 }
 
 func ReadFile(name string) (string, error) {
-	content, err := ioutil.ReadFile(name)
+	content, err := os.ReadFile(name)
 	return string(content), err
 }
 

--- a/pkg/wkspace/builder.go
+++ b/pkg/wkspace/builder.go
@@ -2,7 +2,6 @@ package wkspace
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -172,12 +171,12 @@ func (wk *Workspace) buildExecution(repoRoot string) error {
 	}
 
 	onceFile := pathing.SanitizeFilepath(filepath.Join(wkspaceRoot, ".plural", "ONCE"))
-	if err := ioutil.WriteFile(onceFile, []byte("once"), 0644); err != nil {
+	if err := os.WriteFile(onceFile, []byte("once"), 0644); err != nil {
 		return err
 	}
 
 	nonceFile := pathing.SanitizeFilepath(filepath.Join(wkspaceRoot, ".plural", "NONCE"))
-	if err := ioutil.WriteFile(nonceFile, []byte(crypto.RandString(32)), 0644); err != nil {
+	if err := os.WriteFile(nonceFile, []byte(crypto.RandString(32)), 0644); err != nil {
 		return err
 	}
 

--- a/pkg/wkspace/graph.go
+++ b/pkg/wkspace/graph.go
@@ -45,7 +45,7 @@ func TopSort(client api.Client, installations []*api.Installation) ([]*api.Insta
 			return deps, nil
 		}
 
-		return nil, fmt.Errorf("Unknown repository %s", repo)
+		return nil, fmt.Errorf("unknown repository %s", repo)
 	})
 
 	if err != nil {
@@ -106,7 +106,7 @@ func topsorter(repos []string, fn depsFetcher) ([]string, error) {
 
 	sorted, ok := graph.Toposort()
 	if !ok {
-		return nil, fmt.Errorf("Cycle detected in dependency graph")
+		return nil, fmt.Errorf("cycle detected in dependency graph")
 	}
 
 	// need to reverse the order
@@ -120,7 +120,7 @@ func topsorter(repos []string, fn depsFetcher) ([]string, error) {
 
 func Dependencies(repo string) ([]string, error) {
 	// dfs from the repo to find all dependencies
-	deps, err := containers.DFS[string](repo, func(r string) ([]string, error) {
+	deps, err := containers.DFS(repo, func(r string) ([]string, error) {
 		res := []string{}
 		ds, err := findDependencies(r)
 		if err != nil {

--- a/pkg/wkspace/validator.go
+++ b/pkg/wkspace/validator.go
@@ -63,7 +63,7 @@ func (wk *Workspace) providersValid(providers []string) error {
 	}
 
 	if !pass {
-		return fmt.Errorf("Provider %s is not supported for any of %v", wk.Provider.Name(), providers)
+		return fmt.Errorf("provider %s is not supported for any of %v", wk.Provider.Name(), providers)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Add confirmation dialog when `workspace.yaml` already exist within repo (closes ENG-550)
- Stop using `io/ioutil` package as it's deprecated since Go 1.16
- Apply other static check suggestions like using lowercase in errors etc.
- Update static checker config

## Test Plan
<img width="802" alt="Zrzut ekranu 2022-11-3 o 13 26 31" src="https://user-images.githubusercontent.com/2823399/199723829-5fcc6658-c497-427a-b900-23d0090a528b.png">

Manual check and unit tests.

## Checklist
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.