### PR TITLE
ENG-1003 migrate yaml package to sigs.k8s.io/yaml

### DIFF
--- a/cmd/plural/utils.go
+++ b/cmd/plural/utils.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pluralsh/plural/pkg/utils/pathing"
 	"github.com/thoas/go-funk"
 	"github.com/urfave/cli"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 func utilsCommands() []cli.Command {

--- a/cmd/plural/utils_test.go
+++ b/cmd/plural/utils_test.go
@@ -1,0 +1,83 @@
+package main_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	plural "github.com/pluralsh/plural/cmd/plural"
+	"github.com/stretchr/testify/assert"
+)
+
+const chart_file = `apiVersion: v2
+name: minio
+description: A helm chart for minio
+version: 0.1.0
+appVersion: 0.1.53
+dependencies:
+- name: minio
+  version: 0.1.53
+  repository: cm://app.plural.sh/cm/minio
+  condition: minio.enabled
+`
+
+func TestImageBump(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		values        string
+		expectedChart string
+	}{
+		{
+			name: `test "image-bump" when new version is higher than current`,
+			args: []string{plural.ApplicationName, "utils", "image-bump", "./", "--path", "minio.version", "--tag", "0.1.54"},
+			values: `minio:
+  enabled: true
+  version: 0.1.53`,
+			expectedChart: `apiVersion: v2
+appVersion: 0.1.53
+dependencies:
+- condition: minio.enabled
+  name: minio
+  repository: cm://app.plural.sh/cm/minio
+  version: 0.1.53
+description: A helm chart for minio
+name: minio
+version: 0.1.1
+`,
+		},
+		{
+			name: `test "image-bump" when new version is equal current`,
+			args: []string{plural.ApplicationName, "utils", "image-bump", "./", "--path", "minio.version", "--tag", "0.1.53"},
+			values: `minio:
+  enabled: true
+  version: 0.1.53`,
+			expectedChart: chart_file,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, err := os.MkdirTemp("", "config")
+			assert.NoError(t, err)
+			defer os.RemoveAll(dir)
+
+			err = os.Chdir(dir)
+			assert.NoError(t, err)
+			err = os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte(chart_file), 0644)
+			assert.NoError(t, err)
+			err = os.WriteFile(filepath.Join(dir, "values.yaml"), []byte(test.values), 0644)
+			assert.NoError(t, err)
+
+			app := plural.CreateNewApp(&plural.Plural{Client: nil})
+			app.HelpName = plural.ApplicationName
+			os.Args = test.args
+			_, err = captureStdout(app, os.Args)
+			assert.NoError(t, err)
+
+			newChart, err := os.ReadFile("./Chart.yaml")
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedChart, string(newChart))
+
+		})
+	}
+}

--- a/pkg/api/artifacts.go
+++ b/pkg/api/artifacts.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pluralsh/gqlclient"
 	"github.com/pluralsh/gqlclient/pkg/utils"
 	file "github.com/pluralsh/plural/pkg/utils"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 type ArtifactAttributes struct {

--- a/pkg/api/repos.go
+++ b/pkg/api/repos.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	_ "github.com/AlecAivazis/survey/v2"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/pluralsh/gqlclient"
 	"github.com/pluralsh/gqlclient/pkg/utils"

--- a/pkg/scaffold/application.go
+++ b/pkg/scaffold/application.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pluralsh/plural/pkg/output"
 	"github.com/pluralsh/plural/pkg/utils/git"
 	"github.com/pluralsh/plural/pkg/utils/pathing"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 type Applications struct {

--- a/pkg/scaffold/application_test.go
+++ b/pkg/scaffold/application_test.go
@@ -1,0 +1,67 @@
+package scaffold_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pluralsh/plural/pkg/scaffold"
+	"github.com/stretchr/testify/assert"
+)
+
+const values_file = `console:
+  enabled: true
+  ingress:
+    annotations:
+      external-dns.alpha.kubernetes.io/target: 127.0.0.1
+    console_dns: console.onplural.sh
+  license: abc
+  provider: kind
+`
+
+func TestListRepositories(t *testing.T) {
+	tests := []struct {
+		name             string
+		appName          string
+		expectedResponse map[string]interface{}
+	}{
+		{
+			name:    `test HelmValues`,
+			appName: "test",
+			expectedResponse: map[string]interface{}{
+				"console": map[string]interface{}{
+					"enabled": true,
+					"ingress": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"external-dns.alpha.kubernetes.io/target": "127.0.0.1",
+						},
+						"console_dns": "console.onplural.sh",
+					},
+					"license":  "abc",
+					"provider": "kind",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir, err := os.MkdirTemp("", "config")
+			assert.NoError(t, err)
+			defer os.RemoveAll(dir)
+
+			dirPath := filepath.Join(dir, test.appName, "helm", test.appName)
+			err = os.MkdirAll(dirPath, os.ModePerm)
+			assert.NoError(t, err)
+			err = os.WriteFile(filepath.Join(dirPath, "values.yaml"), []byte(values_file), 0644)
+			assert.NoError(t, err)
+
+			application := scaffold.Applications{
+				Root: dir,
+			}
+			res, err := application.HelmValues("test")
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedResponse, res)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Generally, we can use this package only for yaml.Unmarshal methods. Marshal method converts first to JSON and then to YAML. and it causes major changes in our *.yaml files. I've migrated this package to files when we use `yaml.Unmarshal` and added unit tests first to check if it's safe

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.