### PR TITLE
Extend cli server context apis

### DIFF
--- a/pkg/server/configuration.go
+++ b/pkg/server/configuration.go
@@ -13,6 +13,8 @@ type Configuration struct {
 	Workspace            WorkspaceConfiguration            `json:"workspace"`
 	Git                  GitConfiguration                  `json:"git"`
 	ContextConfiguration map[string]map[string]interface{} `json:"context_configuration,omitempty"`
+	Buckets              []string                          `json:"buckets"`
+	Domains              []string                          `json:"domains"`
 }
 
 type WorkspaceConfiguration struct {
@@ -51,6 +53,8 @@ func configuration(c *gin.Context) error {
 			Cluster:      project.Cluster,
 		},
 		ContextConfiguration: context.Configuration,
+		Buckets:              context.Buckets,
+		Domains:              context.Domains,
 	}
 	if project.Network != nil {
 		configuration.Workspace.Network = &NetworkConfiguration{

--- a/pkg/server/configuration_test.go
+++ b/pkg/server/configuration_test.go
@@ -26,7 +26,7 @@ func TestGetConfiguration(t *testing.T) {
 		{
 			name:               `update configuration console email address`,
 			expectedHTTPStatus: http.StatusOK,
-			expectedResponse:   `{"workspace":{},"git":{"url":"git@git.test.com:portfolio/space.space_name.git","root":"%s","name":"%s","branch":"master"},"context_configuration":{"console":{"email":"test@plural.sh","git_user":"test"},"minio":{"host":"minio.plural.sh","url":"https://test.plural.sh"}}}`,
+			expectedResponse:   `{"workspace":{},"git":{"url":"git@git.test.com:portfolio/space.space_name.git","root":"%s","name":"%s","branch":"master"},"context_configuration":{"console":{"email":"test@plural.sh","git_user":"test"},"minio":{"host":"minio.plural.sh","url":"https://test.plural.sh"}},"buckets":["example-bucket"],"domains":["domain.example.com"]}`,
 		},
 	}
 	for _, test := range tests {
@@ -48,6 +48,8 @@ func TestGetConfiguration(t *testing.T) {
 
 			context := manifest.NewContext()
 			context.Configuration = genDefaultContextConfiguration()
+			context.Buckets = []string{"example-bucket"}
+			context.Domains = []string{"domain.example.com"}
 			err = context.Write(path.Join(dir, "context.yaml"))
 			assert.NoError(t, err)
 


### PR DESCRIPTION
## Summary

The context apis for the server mode of the cli need to support fetching and updating buckets/domains to allow frontends to perform uniqueness validation

## Test Plan
modified tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.