### PR TITLE
Optimistically create kubeconfig in shell

### DIFF
--- a/pkg/server/setup.go
+++ b/pkg/server/setup.go
@@ -129,6 +129,8 @@ func setupCli(c *gin.Context) error {
 		}
 	}
 
+	// try to initialize kubeconfig if we can, but don't stress if it fails
+	_ = execCmd("plural", "wkspace", "kube-init")
 	c.JSON(http.StatusOK, gin.H{"success": true})
 	return nil
 }


### PR DESCRIPTION
## Summary

Shell pods are deleted after a few hours, and then recreated when users enter the shell.  On recreate, kubeconfig isn't regen'ed which can be confusing.  This will help make that not happen and swallow errors if it fails.


## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.