### PR TITLE
fix: get helm values from adjacent apps + clean up empty nested maps

### DIFF
--- a/pkg/scaffold/application.go
+++ b/pkg/scaffold/application.go
@@ -29,15 +29,14 @@ func NewApplications() (*Applications, error) {
 }
 
 func (apps *Applications) HelmValues(app string) (map[string]interface{}, error) {
-	res := make(map[string]interface{})
 	valuesFile := pathing.SanitizeFilepath(filepath.Join(apps.Root, app, "helm", app, "values.yaml"))
 	vals := make(map[string]interface{})
 	valsContent, err := os.ReadFile(valuesFile)
 	if err != nil {
-		return res, err
+		return nil, err
 	}
 	if err := yaml.Unmarshal(valsContent, &vals); err != nil {
-		return res, err
+		return nil, err
 	}
 
 	defaultValuesFile := pathing.SanitizeFilepath(filepath.Join(apps.Root, app, "helm", app, "default-values.yaml"))
@@ -45,19 +44,18 @@ func (apps *Applications) HelmValues(app string) (map[string]interface{}, error)
 	if utils.Exists(defaultValuesFile) {
 		defaultValsContent, err := os.ReadFile(defaultValuesFile)
 		if err != nil {
-			return res, err
+			return nil, err
 		}
 		if err := yaml.Unmarshal(defaultValsContent, &defaultVals); err != nil {
-			return res, err
+			return nil, err
 		}
 	}
 
-	for k, v := range defaultVals {
-		res[k] = v
+	res, err := utils.MergeMap(defaultVals, vals)
+	if err != nil {
+		return nil, err
 	}
-	for k, v := range vals {
-		res[k] = v
-	}
+
 	return res, err
 }
 

--- a/pkg/scaffold/application.go
+++ b/pkg/scaffold/application.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/pluralsh/plural/pkg/output"
+	"github.com/pluralsh/plural/pkg/utils"
 	"github.com/pluralsh/plural/pkg/utils/git"
 	"github.com/pluralsh/plural/pkg/utils/pathing"
 	"sigs.k8s.io/yaml"
@@ -28,14 +29,35 @@ func NewApplications() (*Applications, error) {
 }
 
 func (apps *Applications) HelmValues(app string) (map[string]interface{}, error) {
-	var res map[string]interface{}
-	path := pathing.SanitizeFilepath(filepath.Join(apps.Root, app, "helm", app, "values.yaml"))
-	content, err := os.ReadFile(path)
+	res := make(map[string]interface{})
+	valuesFile := pathing.SanitizeFilepath(filepath.Join(apps.Root, app, "helm", app, "values.yaml"))
+	vals := make(map[string]interface{})
+	valsContent, err := os.ReadFile(valuesFile)
 	if err != nil {
 		return res, err
 	}
+	if err := yaml.Unmarshal(valsContent, &vals); err != nil {
+		return res, err
+	}
 
-	err = yaml.Unmarshal(content, &res)
+	defaultValuesFile := pathing.SanitizeFilepath(filepath.Join(apps.Root, app, "helm", app, "default-values.yaml"))
+	defaultVals := make(map[string]interface{})
+	if utils.Exists(defaultValuesFile) {
+		defaultValsContent, err := os.ReadFile(defaultValuesFile)
+		if err != nil {
+			return res, err
+		}
+		if err := yaml.Unmarshal(defaultValsContent, &defaultVals); err != nil {
+			return res, err
+		}
+	}
+
+	for k, v := range defaultVals {
+		res[k] = v
+	}
+	for k, v := range vals {
+		res[k] = v
+	}
 	return res, err
 }
 

--- a/pkg/scaffold/application_test.go
+++ b/pkg/scaffold/application_test.go
@@ -10,6 +10,11 @@ import (
 )
 
 const values_file = `console:
+  ingress:
+    console_dns: console.onplural.sh
+`
+
+const defaultValues_file = `console:
   enabled: true
   ingress:
     annotations:
@@ -51,6 +56,8 @@ func TestListRepositories(t *testing.T) {
 
 			dirPath := filepath.Join(dir, test.appName, "helm", test.appName)
 			err = os.MkdirAll(dirPath, os.ModePerm)
+			assert.NoError(t, err)
+			err = os.WriteFile(filepath.Join(dirPath, "default-values.yaml"), []byte(defaultValues_file), 0644)
 			assert.NoError(t, err)
 			err = os.WriteFile(filepath.Join(dirPath, "values.yaml"), []byte(values_file), 0644)
 			assert.NoError(t, err)

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -89,6 +89,10 @@ func PatchInterfaceMap(defaultValues, values map[string]map[string]interface{}) 
 		} else {
 			// remove nulls from the map
 			RemoveNulls(patch[key])
+			// if the map is empty after removing nulls, remove it
+			if len(patch[key]) == 0 {
+				delete(patch, key)
+			}
 		}
 	}
 	// if the patch is empty, return an empty map

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -32,6 +32,11 @@ func RemoveNulls(m map[string]interface{}) {
 		if ok {
 			RemoveNulls(t)
 		}
+		// if the map is empty, remove it
+		// TODO: add a unit test for this
+		if ok && len(t) == 0 {
+			delete(m, e.String())
+		}
 	}
 }
 
@@ -55,12 +60,15 @@ func PatchInterfaceMap(defaultValues, values map[string]map[string]interface{}) 
 		return nil, err
 	}
 	for key := range patch {
+		// if the map is empty, remove it
 		if len(patch[key]) == 0 {
 			delete(patch, key)
 		} else {
+			// remove nulls from the map
 			RemoveNulls(patch[key])
 		}
 	}
+	// if the patch is empty, return an empty map
 	if len(patch) == 0 {
 		return map[string]map[string]interface{}{}, nil
 	}

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -40,6 +40,29 @@ func RemoveNulls(m map[string]interface{}) {
 	}
 }
 
+func MergeMap(defaultValues, values map[string]interface{}) (map[string]interface{}, error) {
+	defaultJson, err := json.Marshal(defaultValues)
+	if err != nil {
+		return nil, err
+	}
+	valuesJson, err := json.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+
+	patchJson, err := jsonpatch.MergePatch(defaultJson, valuesJson)
+	if err != nil {
+		return nil, err
+	}
+
+	patch := map[string]interface{}{}
+	if err := json.Unmarshal(patchJson, &patch); err != nil {
+		return nil, err
+	}
+
+	return patch, nil
+}
+
 func PatchInterfaceMap(defaultValues, values map[string]map[string]interface{}) (map[string]map[string]interface{}, error) {
 	defaultJson, err := json.Marshal(defaultValues)
 	if err != nil {

--- a/pkg/utils/map_test.go
+++ b/pkg/utils/map_test.go
@@ -154,7 +154,7 @@ func TestPatchInterfaceMap(t *testing.T) {
 				"test": {"a": "test", "b": 13, "c": map[string]interface{}{"d": "test"}},
 			},
 			values: map[string]map[string]interface{}{
-				"test": map[string]interface{}{},
+				"test": {},
 			},
 			expectedResult: map[string]map[string]interface{}{},
 		},

--- a/pkg/utils/map_test.go
+++ b/pkg/utils/map_test.go
@@ -37,15 +37,97 @@ func TestPatchInterfaceMap(t *testing.T) {
 			},
 		},
 		{
-			name: `test if element was changed`,
+			name: `test if new nested element was added`,
 			defaultValues: map[string]map[string]interface{}{
 				"test": {"a": "test", "b": 13},
 			},
 			values: map[string]map[string]interface{}{
-				"test": {"a": "test", "b": 13, "c": "test"},
+				"test": {"a": "test", "b": 13, "c": map[string]interface{}{"d": "e"}},
 			},
 			expectedResult: map[string]map[string]interface{}{
-				"test": {"c": "test"},
+				"test": {"c": map[string]interface{}{"d": "e"}},
+			},
+		},
+		{
+			name: `test if new element was added to nested element`,
+			defaultValues: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": map[string]interface{}{"d": "e"}},
+			},
+			values: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": map[string]interface{}{"f": "g"}},
+			},
+			expectedResult: map[string]map[string]interface{}{
+				"test": {"c": map[string]interface{}{"f": "g"}},
+			},
+		},
+		{
+			name: `test if nested element was added changed`,
+			defaultValues: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": map[string]interface{}{"d": "e"}},
+			},
+			values: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": map[string]interface{}{"d": "f"}},
+			},
+			expectedResult: map[string]map[string]interface{}{
+				"test": {"c": map[string]interface{}{"d": "f"}},
+			},
+		},
+		{
+			name: `test if element was changed bool true to false`,
+			defaultValues: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": true},
+			},
+			values: map[string]map[string]interface{}{
+				"test": {"a": "test-2", "b": 14, "c": false},
+			},
+			expectedResult: map[string]map[string]interface{}{
+				"test": {"a": "test-2", "b": float64(14), "c": false},
+			},
+		},
+		{
+			name: `test if element was changed bool false to true`,
+			defaultValues: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": false},
+			},
+			values: map[string]map[string]interface{}{
+				"test": {"a": "test-2", "b": 14, "c": true},
+			},
+			expectedResult: map[string]map[string]interface{}{
+				"test": {"a": "test-2", "b": float64(14), "c": true},
+			},
+		},
+		{
+			name: `test with equal list element`,
+			defaultValues: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": []interface{}{"a", "b"}},
+			},
+			values: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": []interface{}{"a", "b"}},
+			},
+			expectedResult: map[string]map[string]interface{}{},
+		},
+		{
+			name: `test with changed list element`,
+			defaultValues: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": []interface{}{"a", "b"}},
+			},
+			values: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": []interface{}{"c", "d"}},
+			},
+			expectedResult: map[string]map[string]interface{}{
+				"test": {"c": []interface{}{"c", "d"}},
+			},
+		},
+		{
+			name: `test with removing element from list`,
+			defaultValues: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": []interface{}{"a", "b"}},
+			},
+			values: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": []interface{}{"a"}},
+			},
+			expectedResult: map[string]map[string]interface{}{
+				"test": {"c": []interface{}{"a"}},
 			},
 		},
 		{
@@ -54,6 +136,26 @@ func TestPatchInterfaceMap(t *testing.T) {
 				"test": {"a": "test", "b": 13},
 			},
 			values:         map[string]map[string]interface{}{},
+			expectedResult: map[string]map[string]interface{}{},
+		},
+		{
+			name: `test with empty nested values`,
+			defaultValues: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": map[string]interface{}{"d": "test"}},
+			},
+			values: map[string]map[string]interface{}{
+				"test": {"c": map[string]interface{}{}},
+			},
+			expectedResult: map[string]map[string]interface{}{},
+		},
+		{
+			name: `test with empty top level map`,
+			defaultValues: map[string]map[string]interface{}{
+				"test": {"a": "test", "b": 13, "c": map[string]interface{}{"d": "test"}},
+			},
+			values: map[string]map[string]interface{}{
+				"test": map[string]interface{}{},
+			},
 			expectedResult: map[string]map[string]interface{}{},
 		},
 	}


### PR DESCRIPTION
## Summary
After https://github.com/pluralsh/plural-cli/pull/301, the ability to get helm values from adjacent applications broke since it was still trying to get those from the `values.yaml` and not a combination of the `default-values.yaml` and `values.yaml`. This PR fixes this. Along the way, it occurred that empty nested maps could be left in the `values.yaml`, which has also been solved.

TODO: we still need to add unit tests for cleaning up the empty maps.

## Test Plan
- Manually test with the apps that were causing problems

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.