### PR TITLE
don't merge previous values

### DIFF
--- a/pkg/scaffold/helm.go
+++ b/pkg/scaffold/helm.go
@@ -197,11 +197,15 @@ func (s *Scaffold) buildChartValues(w *wkspace.Workspace) error {
 		}
 	}
 
-	for k, v := range defaultPrevVals {
-		vals[k] = v
-	}
-	for k, v := range prevVals {
-		vals[k] = v
+	// get previous values from default-values.yaml if exists otherwise from values.yaml
+	if utils.Exists(defaultValuesFile) {
+		for k, v := range defaultPrevVals {
+			vals[k] = v
+		}
+	} else {
+		for k, v := range prevVals {
+			vals[k] = v
+		}
 	}
 
 	defaultValues, err := scftmpl.BuildValuesFromTemplate(vals, w)


### PR DESCRIPTION
## Summary
We should take previous values from `default-values.yaml` if it exists. Otherwise from `values.yaml` (old CLI or new deployment)
Before this fix, we could override some values. We don't need to merge previous values from  `default-values.yaml` and `values.yaml` because it's happening during helm execution `helm upgrade --install`

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.