### PR TITLE
Protect apps from plural destroy

### DIFF
--- a/cmd/plural/deploy.go
+++ b/cmd/plural/deploy.go
@@ -438,7 +438,12 @@ func (p *Plural) doDestroy(repoRoot string, installation *api.Installation, dele
 	if err := os.Chdir(repoRoot); err != nil {
 		return err
 	}
-	utils.Error("\nDestroying application %s\n", installation.Repository.Name)
+	repo := installation.Repository.Name
+	if ctx, err := manifest.FetchContext(); err == nil && ctx.Protected(repo) {
+		return fmt.Errorf("This app is protected, you cannot plural destroy without updating context.yaml")
+	}
+
+	utils.Error("\nDestroying application %s\n", repo)
 	workspace, err := wkspace.New(p.Client, installation)
 	if err != nil {
 		return err
@@ -449,7 +454,7 @@ func (p *Plural) doDestroy(repoRoot string, installation *api.Installation, dele
 	}
 
 	if delete {
-		utils.Highlight("Uninstalling %s from the plural api as well...\n", installation.Repository.Name)
+		utils.Highlight("Uninstalling %s from the plural api as well...\n", repo)
 		return p.Client.DeleteInstallation(installation.Id)
 	}
 

--- a/cmd/plural/plural.go
+++ b/cmd/plural/plural.go
@@ -65,7 +65,7 @@ func (p *Plural) getCommands() []cli.Command {
 					Usage: "force workspace to build even if remote is out of sync",
 				},
 			},
-			Action: tracked(latestVersion(owned(upstreamSynced(p.build))), "cli.build"),
+			Action: tracked(rooted(latestVersion(owned(upstreamSynced(p.build)))), "cli.build"),
 		},
 		{
 			Name:      "deploy",

--- a/pkg/manifest/context.go
+++ b/pkg/manifest/context.go
@@ -32,6 +32,7 @@ type Context struct {
 	Bundles       []*Bundle
 	Buckets       []string
 	Domains       []string
+	Protect       []string `yaml:"protect,omitempty" json:"protect,omitempty"`
 	SMTP          *SMTP    `yaml:"smtp,omitempty"`
 	Globals       *Globals `yaml:"globals,omitempty" json:"globals,omitempty"`
 	Configuration map[string]map[string]interface{}
@@ -115,6 +116,16 @@ func (c *Context) HasBucket(bucket string) bool {
 
 func (c *Context) AddDomain(bucket string) {
 	c.Domains = append(c.Domains, bucket)
+}
+
+func (c *Context) Protected(name string) bool {
+	for _, r := range c.Protect {
+		if r == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c *Context) HasDomain(domain string) bool {


### PR DESCRIPTION
## Summary

This provides a layer of protection against rogue usages of plural destroy for critical apps


## Test Plan
local


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.