### PR TITLE
Fix silent errors on configuration failure

### DIFF
--- a/pkg/bundle/configuration.go
+++ b/pkg/bundle/configuration.go
@@ -25,18 +25,21 @@ func evaluateCondition(ctx map[string]interface{}, cond *api.Condition, valueTyp
 
 	val, ok := ctx[cond.Field]
 	if !ok {
-		return true
+		return cond.Operation == "NOT"
 	}
+
 	condValue := cond.Value
 	operationType := OperationType{
 		Operation: cond.Operation,
 		Type:      valueType,
 	}
 
-	switch operationType {
-	case OperationType{Operation: "NOT", Type: Bool}:
+	if operationType.Operation == "NOT" {
 		booled, ok := val.(bool)
-		return ok && !booled
+		return ok && !booled // it must be a false boolean value
+	}
+
+	switch operationType {
 	case OperationType{Operation: "PREFIX", Type: String}:
 		return strings.HasPrefix(val.(string), condValue)
 	case OperationType{Operation: "SUFFIX", Type: String}:

--- a/pkg/bundle/configuration_test.go
+++ b/pkg/bundle/configuration_test.go
@@ -442,7 +442,7 @@ func TestEvaluateCondition(t *testing.T) {
 			},
 			context: &manifest.Context{},
 			ctx: map[string]interface{}{
-				"test_prefix": "suffix-test",
+				"test_suffix": "suffix-test",
 			},
 			repo:          "test",
 			envVars:       map[string]string{"PLURAL_TEST_TEST_ITEM": "123"},
@@ -457,6 +457,23 @@ func TestEvaluateCondition(t *testing.T) {
 					Field:     "test_suffix",
 					Operation: "SUFFIX",
 					Value:     "test",
+				},
+			},
+			context: &manifest.Context{},
+			ctx: map[string]interface{}{
+				"test_suffix": "suffix-ttt",
+			},
+			repo:          "test",
+			expectedValue: "<nil>",
+		},
+		{
+			name: "test NOT",
+			item: &api.ConfigurationItem{
+				Name: "test_item",
+				Type: bundle.String,
+				Condition: &api.Condition{
+					Field:     "test_suffix",
+					Operation: "NOT",
 				},
 			},
 			context: &manifest.Context{},

--- a/pkg/bundle/installer.go
+++ b/pkg/bundle/installer.go
@@ -58,8 +58,7 @@ func doInstall(client api.Client, recipe *api.Recipe, repo, name string, refresh
 			seen[configItem.Name] = true
 			if err := Configure(ctx, configItem, context, repo); err != nil {
 				context.Configuration[section.Repository.Name] = ctx
-				err := context.Write(path)
-				if err != nil {
+				if err := context.Write(path); err != nil {
 					return err
 				}
 				return err


### PR DESCRIPTION
## Summary
We would swallow config failures before instead of surfacing errors.  Also the NOT condition has a bug in its setup

## Test Plan
local + unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.