### PR TITLE
add `--all` flag to plural destroy

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,7 +30,7 @@ jobs:
       - run: go test -v -race ./pkg/test/e2e/... -tags="e2e"
       - run: |
           cd $HOME/test
-          plural destroy --force --commit=""
+          plural destroy --force --all --commit=""
         env:
           PLURAL_DESTROY_CONFIRM: true
           PLURAL_DESTROY_AFFIRM_UNINSTALL_APPS: true

--- a/cmd/plural/deploy.go
+++ b/cmd/plural/deploy.go
@@ -117,7 +117,6 @@ func (p *Plural) build(c *cli.Context) error {
 }
 
 func (p *Plural) doBuild(installation *api.Installation, force bool) error {
-	p.InitPluralClient()
 	repoName := installation.Repository.Name
 	fmt.Printf("Building workspace for %s\n", repoName)
 
@@ -360,6 +359,7 @@ func (p *Plural) destroy(c *cli.Context) error {
 	repoName := c.Args().Get(0)
 	repoRoot, err := git.Root()
 	force := c.Bool("force")
+	all := c.Bool("all")
 	if err != nil {
 		return err
 	}
@@ -367,6 +367,8 @@ func (p *Plural) destroy(c *cli.Context) error {
 	infix := "this workspace"
 	if repoName != "" {
 		infix = repoName
+	} else if !all {
+		return fmt.Errorf("you must either specify an individual application or `--all` to destroy the entire workspace")
 	}
 
 	if !force && !confirm(fmt.Sprintf("Are you sure you want to destroy %s?", infix), "PLURAL_DESTROY_CONFIRM") {

--- a/cmd/plural/init.go
+++ b/cmd/plural/init.go
@@ -51,7 +51,7 @@ func (p *Plural) handleInit(c *cli.Context) error {
 	}
 
 	prov, err := runPreflights()
-	if err != nil {
+	if err != nil && !c.Bool("ignore-preflights") {
 		return err
 	}
 

--- a/cmd/plural/plural.go
+++ b/cmd/plural/plural.go
@@ -254,6 +254,10 @@ func (p *Plural) getCommands() []cli.Command {
 					Name:  "service-account",
 					Usage: "email for the service account you'd like to use for this workspace",
 				},
+				cli.BoolFlag{
+					Name:  "ignore-preflights",
+					Usage: "whether to ignore preflight check failures prior to init",
+				},
 			},
 			Action: tracked(latestVersion(p.handleInit), "cli.init"),
 		},

--- a/cmd/plural/plural.go
+++ b/cmd/plural/plural.go
@@ -235,6 +235,10 @@ func (p *Plural) getCommands() []cli.Command {
 					Name:  "force",
 					Usage: "use force push when pushing to git",
 				},
+				cli.BoolFlag{
+					Name:  "all",
+					Usage: "tear down the entire cluster gracefully in one go",
+				},
 			},
 			Action: tracked(latestVersion(owned(upstreamSynced(p.destroy))), "cli.destroy"),
 		},

--- a/pkg/scaffold/terraform.go
+++ b/pkg/scaffold/terraform.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/mod/semver"
 
 	"github.com/pluralsh/plural/pkg/api"
+	"github.com/pluralsh/plural/pkg/config"
 	"github.com/pluralsh/plural/pkg/template"
 	"github.com/pluralsh/plural/pkg/utils"
 	"github.com/pluralsh/plural/pkg/utils/pathing"
@@ -122,6 +123,7 @@ func (scaffold *Scaffold) handleTerraform(wk *wkspace.Workspace) error {
 			"Namespace":     wk.Config.Namespace(repo.Name),
 			"Region":        wk.Provider.Region(),
 			"Context":       wk.Provider.Context(),
+			"Config":        config.Read(),
 			"Applications":  apps,
 		}
 		if err := tmpl.Execute(&buf, values); err != nil {


### PR DESCRIPTION
## Summary
This will make a full cluster destroy require an implicit invocation which can prevent mistyping


## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.