### PR TITLE
ci: increase trivy scan timeout on cloud image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,6 +199,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           security-checks: 'vuln'
+          timeout: 10m
           ignore-unfixed: true
            #severity: 'CRITICAL,HIGH'
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/goreleaser-ci.yml
+++ b/.github/workflows/goreleaser-ci.yml
@@ -253,6 +253,7 @@ jobs:
         format: 'sarif'
         output: 'trivy-results.sarif'
         security-checks: 'vuln'
+        timeout: 10m
         ignore-unfixed: true
           #severity: 'CRITICAL,HIGH'
     - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
## Summary
Looks like the trivy image scanning on the cloud image is timing out because it is large. This PR doubles the timeout to 10m on that image.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.