### PR TITLE
Info command

### DIFF
--- a/cmd/plural/deploy.go
+++ b/cmd/plural/deploy.go
@@ -121,7 +121,7 @@ func (p *Plural) doBuild(installation *api.Installation, force bool) error {
 	fmt.Printf("Building workspace for %s\n", repoName)
 
 	if !wkspace.Configured(repoName) {
-		return fmt.Errorf("You have not locally configured %s but have it registered as an installation in our api, either delete it with `plural repos uninstall %s` or install it locally via a bundle in `plural bundle list %s`", repoName, repoName, repoName)
+		return fmt.Errorf("You have not locally configured %s but have it registered as an installation in our api, either delete it with `plural apps uninstall %s` or install it locally via a bundle in `plural bundle list %s`", repoName, repoName, repoName)
 	}
 
 	workspace, err := wkspace.New(p.Client, installation)
@@ -182,6 +182,20 @@ func (p *Plural) doValidate(installation *api.Installation) error {
 	}
 
 	return workspace.Validate()
+}
+
+func (p *Plural) info(c *cli.Context) error {
+	p.InitPluralClient()
+	repo := c.Args().Get(0)
+	installation, err := p.GetInstallation(repo)
+	if err != nil {
+		return api.GetErrorResponse(err, "GetInstallation")
+	}
+	if installation == nil {
+		return fmt.Errorf("You have not installed %s", repo)
+	}
+
+	return scaffold.Notes(installation)
 }
 
 func (p *Plural) deploy(c *cli.Context) error {

--- a/cmd/plural/plural.go
+++ b/cmd/plural/plural.go
@@ -94,6 +94,12 @@ func (p *Plural) getCommands() []cli.Command {
 			Action: tracked(rooted(latestVersion(owned(upstreamSynced(p.build)))), "cli.build"),
 		},
 		{
+			Name:      "info",
+			Usage:     "Get information for your installation of APP",
+			ArgsUsage: "APP",
+			Action:    latestVersion(owned(rooted(p.info))),
+		},
+		{
 			Name:      "deploy",
 			Aliases:   []string{"d"},
 			Usage:     "Deploys the current workspace. This command will first sniff out git diffs in workspaces, topsort them, then apply all changes.",
@@ -313,6 +319,12 @@ func (p *Plural) getCommands() []cli.Command {
 		},
 		{
 			Name:        "repos",
+			Usage:       "view and manage plural repositories",
+			Subcommands: p.reposCommands(),
+			Category:    "API",
+		},
+		{
+			Name:        "apps",
 			Usage:       "view and manage plural repositories",
 			Subcommands: p.reposCommands(),
 			Category:    "API",


### PR DESCRIPTION
## Summary
Adds info command to redisplay the info from the deploy notes for an app.  Also add a new command set for "apps" since "repos" is unintuitive.

## Test Plan
local

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.