### PR TITLE
Fix crypto unlock

### DIFF
--- a/cmd/plural/crypto.go
+++ b/cmd/plural/crypto.go
@@ -15,7 +15,6 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/pluralsh/plural/pkg/api"
-	"github.com/pluralsh/plural/pkg/config"
 	"github.com/pluralsh/plural/pkg/crypto"
 	"github.com/pluralsh/plural/pkg/scm"
 	"github.com/pluralsh/plural/pkg/utils"
@@ -336,21 +335,21 @@ func handleUnlock(c *cli.Context) error {
 	}
 
 	gitIndex, _ := filepath.Abs(filepath.Join(repoRoot, ".git", "index"))
-	dump, err := config.PluralDir("index.bak")
+	dump, err := os.CreateTemp("", "index.bak")
 	if err != nil {
 		return err
 	}
 
-	if err := os.Rename(gitIndex, dump); err != nil {
+	if err := os.Rename(gitIndex, dump.Name()); err != nil {
 		return err
 	}
 
 	if err := gitCommand("checkout", "HEAD", "--", repoRoot).Run(); err != nil {
-		_ = os.Rename(dump, gitIndex)
+		_ = os.Rename(dump.Name(), gitIndex)
 		return errUnlock
 	}
 
-	os.Remove(dump)
+	os.Remove(dump.Name())
 	return nil
 }
 


### PR DESCRIPTION
## Summary
The previous method of preserving the git index fails in the console since its on a separate device (secret volume mount) and is a read-only filesystem.  Just use a tempfile instead


## Test Plan
local


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.