### PR TITLE
fix: add configuration for helm values linting

### DIFF
--- a/pkg/scaffold/template/template.go
+++ b/pkg/scaffold/template/template.go
@@ -151,13 +151,14 @@ func goTmpValuesFile(path string, conf *config.Config) (f *os.File, err error) {
 
 func genDefaultValues(conf *config.Config) map[string]interface{} {
 	return map[string]interface{}{
-		"Values":   map[string]interface{}{},
-		"License":  "example-license",
-		"Region":   "region",
-		"Project":  "example",
-		"Cluster":  "cluster",
-		"Provider": "provider",
-		"Config":   conf,
-		"Context":  map[string]interface{}{},
+		"Values":        map[string]interface{}{},
+		"Configuration": map[string]map[string]interface{}{},
+		"License":       "example-license",
+		"Region":        "region",
+		"Project":       "example",
+		"Cluster":       "cluster",
+		"Provider":      "provider",
+		"Config":        conf,
+		"Context":       map[string]interface{}{},
 	}
 }


### PR DESCRIPTION
## Summary
Before being able to upload a Helm chart to Plural we execute the `values.yaml.tpl` file with dummy values. However, these dummy values didn't include the `.Configuration` field, breaking uploads for templates that make use of this field like https://github.com/pluralsh/plural-artifacts/actions/runs/4617166996/jobs/8163107146. This PR adds the configuration field to the dummy values we pass for the templating.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.