### PR TITLE
Infer bundle name in `bundle install`

### DIFF
--- a/cmd/plural/bundle.go
+++ b/cmd/plural/bundle.go
@@ -29,7 +29,7 @@ func (p *Plural) bundleCommands() []cli.Command {
 					Usage: "re-enter the configuration for this bundle",
 				},
 			},
-			Action: tracked(latestVersion(rooted(requireArgs(p.bundleInstall, []string{"repo", "bundle-name"}))), "bundle.install"),
+			Action: tracked(latestVersion(rooted(p.bundleInstall)), "bundle.install"),
 		},
 	}
 }
@@ -63,15 +63,9 @@ func (p *Plural) stackCommands() []cli.Command {
 }
 
 func (p *Plural) bundleList(c *cli.Context) error {
-	man, err := manifest.FetchProject()
 	repo := c.Args().Get(0)
-	prov := ""
-	if err == nil {
-		prov = strings.ToUpper(man.Provider)
-	}
-
 	p.InitPluralClient()
-	recipes, err := p.ListRecipes(repo, prov)
+	recipes, err := p.listRecipes(repo)
 	if err != nil {
 		return api.GetErrorResponse(err, "ListRecipes")
 	}
@@ -85,7 +79,26 @@ func (p *Plural) bundleList(c *cli.Context) error {
 func (p *Plural) bundleInstall(c *cli.Context) (err error) {
 	args := c.Args()
 	p.InitPluralClient()
-	err = bundle.Install(p.Client, args.Get(0), args.Get(1), c.Bool("refresh"))
+	repo := args.Get(0)
+	if repo == "" {
+		return fmt.Errorf("REPO argument required, try running `plural bundle install REPO` for the app you want to install")
+	}
+
+	bdl := args.Get(1)
+	if bdl == "" {
+		recipes, err := p.listRecipes(args.Get(0))
+		if err != nil {
+			return err
+		}
+		for _, recipe := range recipes {
+			if recipe.Primary {
+				bdl = recipe.Name
+				break
+			}
+		}
+	}
+
+	err = bundle.Install(p.Client, repo, bdl, c.Bool("refresh"))
 	utils.Note("To edit the configuration you've just entered, edit the context.yaml file at the root of your repo, or run with the --refresh flag\n")
 	return
 }
@@ -114,4 +127,15 @@ func (p *Plural) stackList(c *cli.Context) (err error) {
 	return utils.PrintTable(stacks, headers, func(s *api.Stack) ([]string, error) {
 		return []string{s.Name, s.Description, fmt.Sprintf("%v", s.Featured)}, nil
 	})
+}
+
+func (p *Plural) listRecipes(repo string) (res []*api.Recipe, err error) {
+	man, err := manifest.FetchProject()
+	prov := ""
+	if err == nil {
+		prov = strings.ToUpper(man.Provider)
+	}
+
+	res, err = p.ListRecipes(repo, prov)
+	return
 }

--- a/cmd/plural/plural.go
+++ b/cmd/plural/plural.go
@@ -103,7 +103,7 @@ func (p *Plural) getCommands() []cli.Command {
 			Name:      "deploy",
 			Aliases:   []string{"d"},
 			Usage:     "Deploys the current workspace. This command will first sniff out git diffs in workspaces, topsort them, then apply all changes.",
-			ArgsUsage: "WKSPACE",
+			ArgsUsage: "Workspace",
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:  "silence",
@@ -297,7 +297,7 @@ func (p *Plural) getCommands() []cli.Command {
 			Name:     "repair",
 			Usage:    "commits any new encrypted changes in your local workspace automatically",
 			Action:   latestVersion(handleRepair),
-			Category: "WORKSPACE",
+			Category: "Workspace",
 		},
 		{
 			Name:     "serve",

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/packethost/packngo v0.29.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
-	github.com/pluralsh/gqlclient v1.3.14
+	github.com/pluralsh/gqlclient v1.3.15
 	github.com/pluralsh/plural-operator v0.5.3
 	github.com/pluralsh/polly v0.1.1
 	github.com/rodaine/hclencoder v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -901,6 +901,8 @@ github.com/pluralsh/controller-reconcile-helper v0.0.4 h1:1o+7qYSyoeqKFjx+WgQTxD
 github.com/pluralsh/controller-reconcile-helper v0.0.4/go.mod h1:AfY0gtteD6veBjmB6jiRx/aR4yevEf6K0M13/pGan/s=
 github.com/pluralsh/gqlclient v1.3.14 h1:MX3odnIfPSYT9PysegKkC31w/Vn8PZhrT/rZXZck/yU=
 github.com/pluralsh/gqlclient v1.3.14/go.mod h1:z1qHnvPeqIN/a+5OzFs40e6HI6tDxzh1+yJuEpvqGy4=
+github.com/pluralsh/gqlclient v1.3.15 h1:QA6VEMDxeG0/e+qXvr7xgorHl45o4/Qg9CwsPyVn2gE=
+github.com/pluralsh/gqlclient v1.3.15/go.mod h1:z1qHnvPeqIN/a+5OzFs40e6HI6tDxzh1+yJuEpvqGy4=
 github.com/pluralsh/oauth v0.9.2 h1:tM9hBK4tCnJUeCOgX0ctxBBCS3hiCDPoxkJLODtedmQ=
 github.com/pluralsh/oauth v0.9.2/go.mod h1:aTUw/75rzcsbvW+/TLvWtHVDXFIdtFrDtUncOq9vHyM=
 github.com/pluralsh/plural-operator v0.5.3 h1:GaPL3LgimfzKZNHt7zXzqYZpb0hgyW9noHYnkA+rqNs=

--- a/pkg/api/models.go
+++ b/pkg/api/models.go
@@ -173,6 +173,7 @@ type Recipe struct {
 	Name               string
 	Provider           string
 	Description        string
+	Primary            bool
 	Restricted         bool
 	Tests              []*RecipeTest
 	Repository         *Repository

--- a/pkg/api/recipes.go
+++ b/pkg/api/recipes.go
@@ -100,6 +100,8 @@ func (client *client) GetRecipe(repo, name string) (*Recipe, error) {
 	r := &Recipe{
 		Id:                 resp.Recipe.ID,
 		Name:               resp.Recipe.Name,
+		Primary:            resp.Recipe.Primary != nil && *resp.Recipe.Primary,
+		Restricted:         resp.Recipe.Restricted != nil && *resp.Recipe.Restricted,
 		Provider:           string(*resp.Recipe.Provider),
 		Description:        utils.ConvertStringPointer(resp.Recipe.Description),
 		Tests:              []*RecipeTest{},
@@ -122,9 +124,6 @@ func (client *client) GetRecipe(repo, name string) (*Recipe, error) {
 			Id:   resp.Recipe.Repository.ID,
 			Name: resp.Recipe.Repository.Name,
 		}
-	}
-	if resp.Recipe.Restricted != nil {
-		r.Restricted = *resp.Recipe.Restricted
 	}
 
 	for _, dep := range resp.Recipe.RecipeDependencies {
@@ -233,6 +232,8 @@ func convertRecipe(rcp *gqlclient.RecipeFragment) *Recipe {
 	r := &Recipe{
 		Id:                 rcp.ID,
 		Name:               rcp.Name,
+		Primary:            rcp.Primary != nil && *rcp.Primary,
+		Restricted:         rcp.Restricted != nil && *rcp.Restricted,
 		Description:        utils.ConvertStringPointer(rcp.Description),
 		Tests:              []*RecipeTest{},
 		RecipeSections:     []*RecipeSection{},
@@ -252,9 +253,7 @@ func convertRecipe(rcp *gqlclient.RecipeFragment) *Recipe {
 			AuthMethod: string(rcp.OidcSettings.AuthMethod),
 		}
 	}
-	if rcp.Restricted != nil {
-		r.Restricted = *rcp.Restricted
-	}
+
 	if rcp.Provider != nil {
 		provider := *rcp.Provider
 		r.Provider = string(provider)


### PR DESCRIPTION
## Summary
Use primary bundles to auto-infer bundle name on install command


## Test Plan
tested locally in one of our installation repos


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.