### PR TITLE
Minor bug fix: don't write empty encrypted files, they confuse Git

### DIFF
--- a/pkg/scaffold/helm.go
+++ b/pkg/scaffold/helm.go
@@ -149,7 +149,7 @@ func (s *Scaffold) buildChartValues(w *wkspace.Workspace) error {
 	prevVals, _ := prevValues(valuesFile)
 
 	if !utils.Exists(valuesFile) {
-		if err := os.WriteFile(valuesFile, []byte(""), 0644); err != nil {
+		if err := os.WriteFile(valuesFile, []byte("{}\n"), 0644); err != nil {
 			return err
 		}
 	}
@@ -229,9 +229,6 @@ func (s *Scaffold) buildChartValues(w *wkspace.Workspace) error {
 	values, err := yaml.Marshal(patchValues)
 	if err != nil {
 		return err
-	}
-	if len(patchValues) == 0 {
-		values = []byte{}
 	}
 	if err := utils.WriteFile(valuesFile, values); err != nil {
 		return err

--- a/pkg/scaffold/helm_test.go
+++ b/pkg/scaffold/helm_test.go
@@ -36,6 +36,7 @@ test:
   - name: ARM_USE_MSI
     value: "true"
 `,
+			expectedValues: "{}\n",
 			man: &manifest.ProjectManifest{
 				Cluster:  "test",
 				Bucket:   "test",

--- a/pkg/server/configuration_test.go
+++ b/pkg/server/configuration_test.go
@@ -78,7 +78,9 @@ func TestGetConfiguration(t *testing.T) {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", test.expectedHTTPStatus, res.Code, res.Body.String())
 			}
 
-			test.expectedResponse = fmt.Sprintf(test.expectedResponse, dir, filepath.Base(dir))
+			realDir, err := filepath.EvalSymlinks(dir)
+			assert.NoError(t, err)
+			test.expectedResponse = fmt.Sprintf(test.expectedResponse, realDir, filepath.Base(dir))
 
 			if res.Code == http.StatusOK {
 				CompareWithResult(t, res, test.expectedResponse)


### PR DESCRIPTION
## Summary

I bumped into a quirk with Git encryption filter: for some reason, `git diff --stat` and family doesn't call `textconv` if the decrypted file in repo is empty. It compares the decrypted empty file with encrypted file in repo, which results in a permanent phantom diff.

Which would be a minor quirk, but `git diff --shortstat` is what [my zsh prompt](https://github.com/nojhan/liquidprompt) calls to get summary, which means my shell thinks there are some changes and my prompt is red, which is personally annoying.

Liquidprompt is quite popular and it's likely that other similar status tools for shells, editors and such are confused.

All the empty files (so far) were `values.yaml` in Helm directories. This PR lets `yaml.Marshal` write `{}` into the values file, which makes the files not empty and fixes the diff.

Drive-by fix: one unrelated test was failing for me because of a symlink in `$TMPDIR` (AFAIK a normal thing in MacOS), fixed that too.

## Labels
bug-fix


## Test Plan
Ran `plural build` in my repository, ran `make test`

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.