### PR TITLE
Extend remote diff error message

### DIFF
--- a/cmd/plural/errors.go
+++ b/cmd/plural/errors.go
@@ -6,6 +6,6 @@ import (
 
 var (
 	errNoGit      = fmt.Errorf("Could not compare current workspace to origin. Do you have an `origin` remote configured, or does your repo not have an initial commit?")
-	errRemoteDiff = fmt.Errorf("Your local workspace is not in sync with remote. Either `git pull` recent changes or `git push` any missed changes.")
+	errRemoteDiff = fmt.Errorf("Your local workspace is not in sync with remote. Either `git pull` recent changes or `git push` any missed changes.  Also confirm you can authenticate to the origin remote, which you can see with `git remote -v`")
 	errUnlock     = fmt.Errorf("could not decrypt your repo, this is likely due to using the wrong key at ~/.plural/key. The original key might be in a backup or on your previous machine.")
 )


### PR DESCRIPTION
## Summary
A user hit this because they hadn't set up ssh auth for git, perhaps this can help point people in the right direction.


## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.