### PR TITLE
Infer name in `plural link`

### DIFF
--- a/cmd/plural/link.go
+++ b/cmd/plural/link.go
@@ -1,6 +1,8 @@
 package plural
 
 import (
+	"path/filepath"
+
 	"github.com/pluralsh/plural/pkg/manifest"
 	"github.com/urfave/cli"
 )
@@ -35,6 +37,10 @@ func linkCommands() []cli.Command {
 func handleLink(c *cli.Context) error {
 	tool, repo := c.Args().Get(0), c.Args().Get(1)
 	name, path := c.String("name"), c.String("path")
+
+	if name == "" {
+		name = filepath.Base(path)
+	}
 
 	manPath, err := manifest.ManifestPath(repo)
 	if err != nil {


### PR DESCRIPTION
## Summary
The basename of the path is actually always the same as the module name, so we can actually infer this.


## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.