### PR TITLE
fix: Explicitly set CGO_ENABLED=0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,17 +36,19 @@ builds:
     overrides:
       - goos: linux
         goarch: arm64
-        tags: [linux]
+        tags: [ linux ]
         env:
           - CGO_ENABLED=0
       - goos: windows
         goarch: arm64
-        tags: [windows]
+        tags: [ windows ]
         env:
           - CGO_ENABLED=0
   # Build CLI binary without embedded UI for linux. Required by our Console.
   - id: plural-cli-console
-    targets: [linux_amd64]
+    targets:
+      - linux_amd64
+      - linux_arm64
     ldflags:
       - -s
       - -w
@@ -54,21 +56,21 @@ builds:
       - -X "github.com/pluralsh/plural/cmd/plural.Commit={{.Commit}}"
       - -X "github.com/pluralsh/plural/cmd/plural.Date={{.Date}}"
       - -X "github.com/pluralsh/plural/pkg/scm.GitlabClientSecret={{.Env.GITLAB_CLIENT_SECRET}}"
-    tags: [linux]
+    tags: [ linux ]
     env:
       - CGO_ENABLED=0
     binary: plural
 
 archives:
   - id: plural-cli
-    builds: [plural-cli]
+    builds: [ plural-cli ]
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
   - id: plural-cli-console
-    builds: [plural-cli-console]
+    builds: [ plural-cli-console ]
     name_template: >-
       {{ .ProjectName }}_console_{{ .Version }}_
       {{- title .Os }}_
@@ -98,7 +100,7 @@ release:
 
 brews:
   - name: plural
-    ids: [plural-cli]
+    ids: [ plural-cli ]
     tap:
       owner: pluralsh
       name: homebrew-plural

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,6 +55,8 @@ builds:
       - -X "github.com/pluralsh/plural/cmd/plural.Date={{.Date}}"
       - -X "github.com/pluralsh/plural/pkg/scm.GitlabClientSecret={{.Env.GITLAB_CLIENT_SECRET}}"
     tags: [linux]
+    env:
+      - CGO_ENABLED=0
     binary: plural
 
 archives:


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Explicitly set `CGO_ENABLED=0` to make sure that dedicated console cli builds do not enable it automatically.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.