### PR TITLE
Modify aws auth configmap manually to solve migration chicken-egg

### DIFF
--- a/cmd/plural/clusters.go
+++ b/cmd/plural/clusters.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pluralsh/plural/pkg/api"
 	"github.com/pluralsh/plural/pkg/bootstrap"
+	"github.com/pluralsh/plural/pkg/bootstrap/aws"
 	"github.com/pluralsh/plural/pkg/cluster"
 	"github.com/pluralsh/plural/pkg/config"
 	"github.com/pluralsh/plural/pkg/kubernetes"
@@ -12,6 +13,7 @@ import (
 	"github.com/pluralsh/plural/pkg/manifest"
 	"github.com/pluralsh/plural/pkg/utils"
 	"github.com/urfave/cli"
+	"sigs.k8s.io/yaml"
 )
 
 func (p *Plural) clusterCommands() []cli.Command {
@@ -83,6 +85,11 @@ func (p *Plural) clusterCommands() []cli.Command {
 			Action:   latestVersion(rooted(initKubeconfig(handleMigration))),
 			Category: "Publishing",
 		},
+		{
+			Name:        "aws-auth",
+			Usage:       "fetches the current state of your aws auth config map",
+			Subcommands: awsAuthCommands(),
+		},
 	}
 }
 
@@ -98,6 +105,54 @@ func handleMigration(_ *cli.Context) error {
 	}
 
 	return bootstrap.MigrateCluster(RunPlural)
+}
+
+func awsAuthCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:   "fetch",
+			Usage:  "gets the current state of your aws auth configmap",
+			Action: handleAwsAuth,
+		},
+		{
+			Name:  "update",
+			Usage: "adds a user or role to the aws auth configmap",
+			Flags: []cli.Flag{
+				cli.StringFlag{Name: "role-arn"},
+				cli.StringFlag{Name: "user-arn"},
+			},
+			Action: handleModifyAwsAuth,
+		},
+	}
+}
+
+func handleAwsAuth(c *cli.Context) error {
+	auth, err := aws.FetchAuth()
+	if err != nil {
+		return err
+	}
+
+	res, err := yaml.Marshal(auth)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(res))
+	return nil
+}
+
+func handleModifyAwsAuth(c *cli.Context) error {
+	role, user := c.String("role-arn"), c.String("user-arn")
+
+	if role != "" {
+		return aws.AddRole(role)
+	}
+
+	if user != "" {
+		return aws.AddUser(user)
+	}
+
+	return fmt.Errorf("you must specify at least one of role-arn or user-arn")
 }
 
 func handleClusterWait(c *cli.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	sigs.k8s.io/application v0.8.3
 	sigs.k8s.io/cluster-api v1.4.3
 	sigs.k8s.io/cluster-api-operator v0.2.0
+	sigs.k8s.io/cluster-api-provider-aws/v2 v2.1.4
 	sigs.k8s.io/kind v0.18.0
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -95,6 +96,7 @@ require (
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
+	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
@@ -278,7 +280,6 @@ require (
 	k8s.io/kube-aggregator v0.25.2 // indirect
 	k8s.io/kubelet v0.25.2 // indirect
 	monis.app/mlog v0.0.4 // indirect
-	sigs.k8s.io/cluster-api-provider-aws/v2 v2.1.4 // indirect
 	sigs.k8s.io/gateway-api v0.5.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/pkg/bootstrap/aws/auth.go
+++ b/pkg/bootstrap/aws/auth.go
@@ -1,0 +1,137 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pluralsh/plural/pkg/kubernetes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	awsAuthNs   = "kube-system"
+	awsAuthName = "aws-auth"
+	roleKey     = "mapRoles"
+	usersKey    = "mapUsers"
+)
+
+func FetchAuth() (*ekscontrolplanev1.IAMAuthenticatorConfig, error) {
+	ctx := context.Background()
+	kube, err := kubernetes.Kubernetes()
+	if err != nil {
+		return nil, err
+	}
+
+	return fetchAwsAuth(ctx, kube)
+}
+
+func AddUser(userArn string) error {
+	ctx := context.Background()
+	kube, err := kubernetes.Kubernetes()
+	if err != nil {
+		return err
+	}
+
+	eksConfig, err := fetchAwsAuth(ctx, kube)
+	if err != nil {
+		return err
+	}
+
+	eksConfig.UserMappings = append(eksConfig.UserMappings, ekscontrolplanev1.UserMapping{
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			Groups:   []string{"system:masters"},
+			UserName: username(userArn),
+		},
+		UserARN: userArn,
+	})
+
+	return persistAuth(ctx, kube, eksConfig)
+}
+
+func AddRole(roleArn string) error {
+	ctx := context.Background()
+	kube, err := kubernetes.Kubernetes()
+	if err != nil {
+		return err
+	}
+
+	eksConfig, err := fetchAwsAuth(ctx, kube)
+	if err != nil {
+		return err
+	}
+
+	eksConfig.RoleMappings = append(eksConfig.RoleMappings, ekscontrolplanev1.RoleMapping{
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			Groups:   []string{"system:masters"},
+			UserName: username(roleArn),
+		},
+		RoleARN: roleArn,
+	})
+
+	return persistAuth(ctx, kube, eksConfig)
+}
+
+func username(arn string) string {
+	parts := strings.Split(arn, "/")
+	return parts[len(parts)-1]
+}
+
+func fetchAwsAuth(ctx context.Context, kube kubernetes.Kube) (*ekscontrolplanev1.IAMAuthenticatorConfig, error) {
+	client := kube.GetClient()
+	cm, err := client.CoreV1().ConfigMaps(awsAuthNs).Get(ctx, awsAuthName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ekscontrolplanev1.IAMAuthenticatorConfig{
+		RoleMappings: []ekscontrolplanev1.RoleMapping{},
+		UserMappings: []ekscontrolplanev1.UserMapping{},
+	}
+
+	if rolesSection, ok := cm.Data[roleKey]; ok {
+		err := yaml.Unmarshal([]byte(rolesSection), &res.RoleMappings)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshalling mapped roles: %w", err)
+		}
+	}
+
+	if usersSection, ok := cm.Data[usersKey]; ok {
+		err := yaml.Unmarshal([]byte(usersSection), &res.UserMappings)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshalling mapped users: %w", err)
+		}
+	}
+
+	return res, nil
+}
+
+func persistAuth(ctx context.Context, kube kubernetes.Kube, authConfig *ekscontrolplanev1.IAMAuthenticatorConfig) error {
+	client := kube.GetClient()
+	cmClient := client.CoreV1().ConfigMaps(awsAuthNs)
+	cm, err := cmClient.Get(ctx, awsAuthName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(authConfig.RoleMappings) > 0 {
+		roleMappings, err := yaml.Marshal(authConfig.RoleMappings)
+		if err != nil {
+			return fmt.Errorf("marshalling auth config roles: %w", err)
+		}
+		cm.Data[roleKey] = string(roleMappings)
+	}
+
+	if len(authConfig.UserMappings) > 0 {
+		userMappings, err := yaml.Marshal(authConfig.UserMappings)
+		if err != nil {
+			return fmt.Errorf("marshalling auth config users: %w", err)
+		}
+		cm.Data[usersKey] = string(userMappings)
+	}
+
+	_, err = cmClient.Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}


### PR DESCRIPTION
## Summary
This allows us to reusably modify the aws-auth configmap for eks from the client which should help resolve some migration-time issues


## Test Plan
tested locally from subcommands


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.