### PR TITLE
bump migrator version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/packethost/packngo v0.29.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
-	github.com/pluralsh/cluster-api-migration v0.2.8
+	github.com/pluralsh/cluster-api-migration v0.2.9
 	github.com/pluralsh/gqlclient v1.10.0
 	github.com/pluralsh/plural-operator v0.5.5
 	github.com/pluralsh/polly v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1384,8 +1384,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
-github.com/pluralsh/cluster-api-migration v0.2.8 h1:ixA88yb6XU/QNLoA5wyPdf6u23mC+fhOxL0bbwfsxuI=
-github.com/pluralsh/cluster-api-migration v0.2.8/go.mod h1:J6lEvC/70KouikX16mE331cxc3y3sBwtmfHGwZqu06w=
+github.com/pluralsh/cluster-api-migration v0.2.9 h1:F5WqXdPPMv0dlyJPFIaHxeIBWE7KxpRlWkV7IQXe1xE=
+github.com/pluralsh/cluster-api-migration v0.2.9/go.mod h1:J6lEvC/70KouikX16mE331cxc3y3sBwtmfHGwZqu06w=
 github.com/pluralsh/controller-reconcile-helper v0.0.4 h1:1o+7qYSyoeqKFjx+WgQTxDz4Q2VMpzprJIIKShxqG0E=
 github.com/pluralsh/controller-reconcile-helper v0.0.4/go.mod h1:AfY0gtteD6veBjmB6jiRx/aR4yevEf6K0M13/pGan/s=
 github.com/pluralsh/gqlclient v1.10.0 h1:ccYB+A0JbPYkEeVzdfajd29l65N6x/buSKPMMxM8OIA=


### PR DESCRIPTION
## Summary
Updates the migrator version so it can be used with the changes from https://github.com/pluralsh/plural-artifacts/pull/819.