### PR TITLE
ci: fix buildx cleanup on AWS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: always()
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::312272277431:role/github-actions/buildx-deployments
+          role-session-name: PluralCLI
   cloud:
     name: Build cloud image
     runs-on: ubuntu-latest
@@ -206,6 +213,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: always()
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::312272277431:role/github-actions/buildx-deployments
+          role-session-name: PluralCLI
   dind:
     name: Build dind image
     runs-on: ubuntu-latest
@@ -306,7 +320,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
-
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: always()
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::312272277431:role/github-actions/buildx-deployments
+          role-session-name: PluralCLI
   trivy-scan:
     name: Trivy fs scan
     runs-on: ubuntu-latest
@@ -338,7 +358,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
       - run: make test
   lint:
     name: Lint
@@ -347,7 +367,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/goreleaser-cd.yml
+++ b/.github/workflows/goreleaser-cd.yml
@@ -233,6 +233,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: always()
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::312272277431:role/github-actions/buildx-deployments
+          role-session-name: PluralCLI
   packer:
     name: Build EKS AMI
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
It seems as though the login to AWS for our multi-arch image building sometimes times out so buildx can't cleanup the build deployments leaving dormant nodes in the cluster. This PR has the action login to AWS again at the end so it should be able to always cleanup the deployments.