### PR TITLE
Fix executor println

### DIFF
--- a/pkg/executor/execution.go
+++ b/pkg/executor/execution.go
@@ -60,7 +60,7 @@ func (e *Execution) Execute(actionName string, verbose bool) error {
 		return err
 	}
 
-	fmt.Printf("actionName %s.  This may take a while, so hold on to your butts\n", e.Metadata.Path)
+	fmt.Printf("%s %s.  This may take a while, so hold on to your butts\n", actionName, e.Metadata.Path)
 	for i, step := range e.Steps {
 		prev := step.Verbose
 		if verbose {


### PR DESCRIPTION
## Summary
This was always saying "actionName <app>" instead of the passed action name.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.