### PR TITLE
fix: properly pass arguments to template on push

### DIFF
--- a/cmd/plural/push.go
+++ b/cmd/plural/push.go
@@ -103,6 +103,7 @@ func handleHelmTemplate(c *cli.Context) error {
 		_ = os.Remove(name)
 	}(f.Name())
 
+	name := "default"
 	namespace := "default"
 	actionConfig, err := helm.GetActionConfig(namespace)
 	if err != nil {
@@ -112,7 +113,7 @@ func handleHelmTemplate(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	res, err := helm.Template(actionConfig, c.Args().Get(0), namespace, "./", false, false, values)
+	res, err := helm.Template(actionConfig, name, namespace, c.Args().Get(0), false, false, values)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Our CLI has the `plural template` function which is run before a chart is pushed to Plural, as well as on the Plural server itself. It does this so that there is server side validation and to find image dependencies of helm charts. On the server the helm chart is packaged as a `.tar.gz` file and thus the template command needs to load the chart from that file. Currently the template command was hardcoding a path rather than having the first argument be the path. This PR fixes this by having the first argument used for the path.

## Test Plan
Create a `.tar.gz` file of the istio helm chart by running `helm package istio/helm/istio` and then run `plural template istio-0.2.1.tgz --values istio/helm/istio/values.yaml.tpl`


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.