### PR TITLE
ci: fix setting packer cli version for validate

### DIFF
--- a/.github/workflows/goreleaser-cd.yml
+++ b/.github/workflows/goreleaser-cd.yml
@@ -273,6 +273,8 @@ jobs:
         run: "packer init ./packer/"
       - name: Run `packer validate`
         id: validate
+        env:
+          PKR_VAR_k8s_cli_version: ${{ github.ref_name}}
         run: "packer validate ./packer/"
       - name: Run `packer build`
         id: build


### PR DESCRIPTION
## Summary
Fixes setting a missing environment variable when running `packer validate`. See https://github.com/pluralsh/plural-cli/actions/runs/6166843356/job/16744098912