### PR TITLE
wip: feat(capi): add support for external cert-manager module

### DIFF
--- a/cmd/plural/plural.go
+++ b/cmd/plural/plural.go
@@ -88,7 +88,7 @@ func (p *Plural) getCommands() []cli.Command {
 			Aliases: []string{"bld"},
 			Usage:   "builds your workspace",
 			Flags: []cli.Flag{
-				cli.StringFlag{
+				cli.StringSliceFlag{
 					Name:  "only",
 					Usage: "repository to (re)build",
 				},

--- a/pkg/bootstrap/common.go
+++ b/pkg/bootstrap/common.go
@@ -133,6 +133,7 @@ func getBootstrapFlags(prov string) []string {
 	switch prov {
 	case api.ProviderAWS:
 		return []string{
+			"--set", "bootstrap.cert-manager.enabled=true",
 			"--set", "cluster-api-provider-aws.cluster-api-provider-aws.bootstrapMode=true",
 			"--set", "bootstrap.aws-ebs-csi-driver.enabled=false",
 			"--set", "bootstrap.aws-load-balancer-controller.enabled=false",
@@ -146,12 +147,14 @@ func getBootstrapFlags(prov string) []string {
 		}
 	case api.ProviderAzure:
 		return []string{
+			"--set", "bootstrap.cert-manager.enabled=true",
 			"--set", "cluster-api-cluster.cluster.azure.clusterIdentity.bootstrapMode=true",
 			"--set", "bootstrap.external-dns.enabled=false",
 			"--set", "plural-certmanager-webhook.enabled=false",
 		}
 	case api.ProviderGCP:
 		return []string{
+			"--set", "bootstrap.cert-manager.enabled=true",
 			"--set", "bootstrap.cert-manager.serviceAccount.create=true",
 			"--set", "cluster-api-provider-gcp.cluster-api-provider-gcp.bootstrapMode=true",
 			"--set", "bootstrap.external-dns.enabled=false",
@@ -174,12 +177,16 @@ func getKubeconfigPath() (string, error) {
 
 // GetBootstrapPath returns bootstrap repository path.
 func GetBootstrapPath() (string, error) {
+	return GetModulePath("bootstrap")
+}
+
+func GetModulePath(module string) (string, error) {
 	gitRootPath, err := git.Root()
 	if err != nil {
 		return "", err
 	}
 
-	return pathing.SanitizeFilepath(filepath.Join(gitRootPath, "bootstrap")), nil
+	return pathing.SanitizeFilepath(filepath.Join(gitRootPath, module)), nil
 }
 
 // GetStepPath returns path from which step will be executed.

--- a/pkg/bootstrap/migrate.go
+++ b/pkg/bootstrap/migrate.go
@@ -380,8 +380,20 @@ func getMigrationSteps(runPlural ActionFunc) ([]*Step, error) {
 			Retries: 2,
 		},
 		{
+			Name:       "Install cert-manager bundle",
+			Args:       []string{"plural", "bundle", "install", "cert-manager", fmt.Sprintf("cert-manager-%s", man.Provider)},
+			TargetPath: gitRootDir,
+			Execute:    runPlural,
+		},
+		{
+			Name:       "Build values",
+			Args:       []string{"plural", "build --only", "cert-manager", "--only" , "bootstrap", "--force"},
+			TargetPath: gitRootDir,
+			Execute:    runPlural,
+		},
+		{
 			Name:       "Run deploy",
-			Args:       []string{"plural", "deploy", "--from", "bootstrap", "--silence", "--commit", "migrate to cluster api"},
+			Args:       []string{"plural", "deploy", "--from", "cert-manager", "--silence", "--commit", "migrate to cluster api"},
 			TargetPath: gitRootDir,
 			Execute:    runPlural,
 		},


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
This updates CAPI cluster bootstrap and migrate to work with external `cert-manager` module.

Depends on https://github.com/pluralsh/plural-artifacts/pull/829

TODO:
- [ ] Update recipes to depend on external `cert-manager` module after the above PR gets merged

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Tested on GCP. Azure/AWS tests should follow.

### Fresh CAPI deploy
Pre: The test recipe needs to be updated with a new `cert-manager` section.
```yaml
  - name: cert-manager
    configuration: []
    items:
      - type: HELM
        name: cert-manager
      - type: TERRAFORM
        name: gcp
      - type: TERRAFORM
        name: kube
```

1. Link `bootstrap` helm module from `plural-artifacts` (required only until it gets merged).
2. Bootstrap CAPI cluster.

### Migration
1. Bootstrap standard TF-based cluster.
2. Link `bootstrap` helm module from `plural-artifacts` (required only until it gets merged).
4. Run `plural clusters migrate`. It should install `cert-manager` into `cert-manager` namespace at the end and remove old installation from `bootstrap` namespace.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.