### PR TITLE
Use `git rev-parse` instead of gogit.Repository.Head() to find out head branch & sha

### DIFF
--- a/pkg/utils/git/repo.go
+++ b/pkg/utils/git/repo.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"bufio"
-	"fmt"
 	"strings"
 
 	gogit "github.com/go-git/go-git/v5"
@@ -21,33 +20,22 @@ func Repo() (*gogit.Repository, error) {
 	return gogit.PlainOpen(root)
 }
 
-func CurrentBranch() (b string, err error) {
-	repo, err := Repo()
-	if err != nil {
-		return
-	}
-
-	ref, err := repo.Head()
-	if err != nil {
-		return
-	}
-
-	b = ref.Name().Short()
-	return
+func CurrentBranch() (string, error) {
+	return GitRaw("rev-parse", "--abbrev-ref", "HEAD")
 }
 
 func HasUpstreamChanges() (bool, string, error) {
-	repo, err := Repo()
+	headRef, err := GitRaw("rev-parse", "--symbolic-full-name", "HEAD")
 	if err != nil {
 		return false, "", err
 	}
 
-	ref, err := repo.Head()
+	headSha, err := GitRaw("rev-parse", "HEAD")
 	if err != nil {
 		return false, "", err
 	}
 
-	res, err := GitRaw("ls-remote", "origin", "-h", fmt.Sprintf("refs/heads/%s", ref.Name().Short()))
+	res, err := GitRaw("ls-remote", "origin", "-h", headRef)
 	if err != nil {
 		return false, "", err
 	}
@@ -62,7 +50,7 @@ func HasUpstreamChanges() (bool, string, error) {
 		}
 	}
 
-	return remote == ref.Hash().String(), remote, nil
+	return remote == headSha, remote, nil
 }
 
 func Init() (string, error) {


### PR DESCRIPTION
## Summary

When working in a `git worktree` rather than a full clone, `plural build` fails:

```
$ plural --debug build --only console
ERROR: 2023/10/03 14:11:38 validation.go:196: reference not found
2023/10/03 14:11:38 Failed to get git information: Could not compare current workspace to origin. Do you have an `origin` remote configured, or does your repo not have an initial commit?
```

I managed to track it down to `gogit.Repository.Head()` function: it seems to try to directly access objects in `.git/`. In worktree, `.git` is a file with reference to a parent repository, so there's no `.git/HEAD`.

This change uses actual `git` CLI instead of an incomplete reimplementation to get HEAD SHA and branch name. This makes Plural CLI work in a `git worktree`.

Some unrelated unit tests are failing, haven't touched these.

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.