### PR TITLE
fix: disable windows_arm64 cli build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,9 @@ builds:
       - linux_amd64
       - linux_arm64
       - windows_amd64
-      - windows_arm64
+# TODO: Re-enable once fixed
+# Ref: https://github.com/golang/go/issues/51019
+#      - windows_arm64
       - darwin_amd64
       - darwin_arm64
     env:


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
There is a known issue related to out of memory error when building for windows arm64: https://github.com/golang/go/issues/51019

Disabling it for now for further investigation.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.