### PR TITLE
feat: add `deployments clusters get-credentials` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/packethost/packngo v0.29.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pluralsh/cluster-api-migration v0.2.15
-	github.com/pluralsh/console-client-go v0.0.20
+	github.com/pluralsh/console-client-go v0.0.23
 	github.com/pluralsh/gqlclient v1.10.0
 	github.com/pluralsh/plural-operator v0.5.5
 	github.com/pluralsh/polly v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1419,10 +1419,8 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pluralsh/cluster-api-migration v0.2.15 h1:TIfusD+wnhZTGmwNfIlKlKJOT2dE3rUaZawDJw98GjY=
 github.com/pluralsh/cluster-api-migration v0.2.15/go.mod h1:J6lEvC/70KouikX16mE331cxc3y3sBwtmfHGwZqu06w=
-github.com/pluralsh/console-client-go v0.0.18 h1:GhfThwExfyQbU+NjMLdxH0KPuVJjdsI5NdK0cdTcakA=
-github.com/pluralsh/console-client-go v0.0.18/go.mod h1:kZjk0pXAWnvyj+miXveCho4kKQaX1Tm3CGAM+iwurWU=
-github.com/pluralsh/console-client-go v0.0.20 h1:1VrFYctcVGQ9K0q1SlThJtxX03vP2rAZHoChFUOY2JM=
-github.com/pluralsh/console-client-go v0.0.20/go.mod h1:kZjk0pXAWnvyj+miXveCho4kKQaX1Tm3CGAM+iwurWU=
+github.com/pluralsh/console-client-go v0.0.23 h1:BH+uZDeSo6P4xqtc6hdZnEYST0SZs5AEQJwGHxlrYco=
+github.com/pluralsh/console-client-go v0.0.23/go.mod h1:kZjk0pXAWnvyj+miXveCho4kKQaX1Tm3CGAM+iwurWU=
 github.com/pluralsh/controller-reconcile-helper v0.0.4 h1:1o+7qYSyoeqKFjx+WgQTxDz4Q2VMpzprJIIKShxqG0E=
 github.com/pluralsh/controller-reconcile-helper v0.0.4/go.mod h1:AfY0gtteD6veBjmB6jiRx/aR4yevEf6K0M13/pGan/s=
 github.com/pluralsh/gqlclient v1.10.0 h1:ccYB+A0JbPYkEeVzdfajd29l65N6x/buSKPMMxM8OIA=


### PR DESCRIPTION
Add `plural deployments clusters get-credentials CLUSTER_ID` command that updates kubeconfig file with appropriate credentials to point to specified cluster. It will overwrite existing cluster, user and context info connected with cluster name in the kubeconfig.

```
➜ plural deployments clusters get-credentials da6fcb3c-ef8d-4042-a821-77a2efe6ad14
set your kubectl context to cd-demo-workload-1

➜ k config current-context
cd-demo-workload-1

➜ k get node 
NAME                                                  STATUS   ROLES    AGE   VERSION
gke-cd-demo-workload-small-burst-on-d-6d59f76e-t8jt   Ready    <none>   19h   v1.26.5-gke.2700
gke-cd-demo-workload-small-burst-on-d-ac65e011-55to   Ready    <none>   19h   v1.26.5-gke.2700
gke-cd-demo-workload-small-burst-on-d-f88016f6-6r14   Ready    <none>   19h   v1.26.5-gke.2700
```