### PR TITLE
Implement `plural cd clusters delete`

### DIFF
--- a/pkg/console/clusters.go
+++ b/pkg/console/clusters.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"fmt"
+
 	consoleclient "github.com/pluralsh/console-client-go"
 	"github.com/pluralsh/plural/pkg/api"
 )
@@ -43,4 +44,9 @@ func (c *consoleClient) UpdateCluster(id string, attr consoleclient.ClusterUpdat
 	}
 
 	return result, nil
+}
+
+func (c *consoleClient) DeleteCluster(id string) error {
+	_, err := c.client.DeleteCluster(c.ctx, id)
+	return api.GetErrorResponse(err, "DeleteCluster")
 }

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -17,6 +17,7 @@ type ConsoleClient interface {
 	ListClusters() (*consoleclient.ListClusters, error)
 	GetCluster(clusterId, clusterName *string) (*consoleclient.ClusterFragment, error)
 	UpdateCluster(id string, attr consoleclient.ClusterUpdateAttributes) (*consoleclient.UpdateCluster, error)
+	DeleteCluster(id string) error
 	ListClusterServices(clusterId, handle *string) ([]*consoleclient.ServiceDeploymentEdgeFragment, error)
 	CreateRepository(url string, privateKey, passphrase, username, password *string) (*consoleclient.CreateGitRepository, error)
 	ListRepositories() (*consoleclient.ListGitRepositories, error)


### PR DESCRIPTION
## Summary
When the console-client-go pr is merged, we can implement the `--soft` flag too.

## Test Plan
local


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.