### PR TITLE
Add ability to soft delete clusters

### DIFF
--- a/cmd/plural/cd_clusters.go
+++ b/cmd/plural/cd_clusters.go
@@ -220,6 +220,10 @@ func (p *Plural) handleDeleteCluster(c *cli.Context) error {
 		return fmt.Errorf("this cluster does not exist")
 	}
 
+	if c.Bool("soft") {
+		return p.ConsoleClient.DetachCluster(existing.ID)
+	}
+
 	return p.ConsoleClient.DeleteCluster(existing.ID)
 }
 func (p *Plural) handleGetClusterCredentials(c *cli.Context) error {

--- a/pkg/console/clusters.go
+++ b/pkg/console/clusters.go
@@ -51,6 +51,11 @@ func (c *consoleClient) DeleteCluster(id string) error {
 	return api.GetErrorResponse(err, "DeleteCluster")
 }
 
+func (c *consoleClient) DetachCluster(id string) error {
+	_, err := c.client.DetachCluster(c.ctx, id)
+	return api.GetErrorResponse(err, "DetachCluster")
+}
+
 func (c *consoleClient) CreateCluster(attributes consoleclient.ClusterAttributes) (*consoleclient.CreateCluster, error) {
 	newCluster, err := c.client.CreateCluster(c.ctx, attributes)
 	if err != nil {

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -22,6 +22,7 @@ type ConsoleClient interface {
 	GetCluster(clusterId, clusterName *string) (*consoleclient.ClusterFragment, error)
 	UpdateCluster(id string, attr consoleclient.ClusterUpdateAttributes) (*consoleclient.UpdateCluster, error)
 	DeleteCluster(id string) error
+	DetachCluster(id string) error
 	ListClusterServices(clusterId, handle *string) ([]*consoleclient.ServiceDeploymentEdgeFragment, error)
 	CreateRepository(url string, privateKey, passphrase, username, password *string) (*consoleclient.CreateGitRepository, error)
 	ListRepositories() (*consoleclient.ListGitRepositories, error)


### PR DESCRIPTION
## Summary
Use the detach api to implement this, useful for deleting clusters that were never properly created or deleting w/o draining services if you want to leave them in-place.


## Test Plan
n/a

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.