### PR TITLE
Add ability to `plural up` in pre-init'ed repos

### DIFF
--- a/cmd/plural/up.go
+++ b/cmd/plural/up.go
@@ -32,6 +32,10 @@ func (p *Plural) handleUp(c *cli.Context) error {
 		return err
 	}
 
+	if err := ctx.Backfill(); err != nil {
+		return err
+	}
+
 	if err := ctx.Generate(); err != nil {
 		return err
 	}

--- a/pkg/bundle/surveys.go
+++ b/pkg/bundle/surveys.go
@@ -101,14 +101,14 @@ func fileSurvey(def string, item *api.ConfigurationItem) (prompt survey.Prompt, 
 			if err != nil {
 				path = toComplete
 			}
-			files, _ := filepath.Glob(cleanPath(path) + "*")
+			files, _ := filepath.Glob(CleanPath(path) + "*")
 			return files
 		},
 	}
 	return
 }
 
-func cleanPath(path string) string {
+func CleanPath(path string) string {
 	if strings.HasSuffix(path, "/") {
 		return path
 	}

--- a/pkg/up/context.go
+++ b/pkg/up/context.go
@@ -3,15 +3,38 @@ package up
 import (
 	"path/filepath"
 
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/pluralsh/plural-cli/pkg/bundle"
 	"github.com/pluralsh/plural-cli/pkg/config"
 	"github.com/pluralsh/plural-cli/pkg/manifest"
 	"github.com/pluralsh/plural-cli/pkg/provider"
+	"github.com/pluralsh/plural-cli/pkg/utils"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 type Context struct {
 	Provider provider.Provider
 	Manifest *manifest.ProjectManifest
 	Config   *config.Config
+}
+
+func (ctx *Context) Backfill() error {
+	context, err := manifest.FetchContext()
+	if err != nil {
+		return backfillConsoleContext(ctx.Manifest)
+	}
+
+	console, ok := context.Configuration["console"]
+	if !ok {
+		return backfillConsoleContext(ctx.Manifest)
+	}
+
+	if _, ok = console["private_key"]; !ok {
+		return backfillConsoleContext(ctx.Manifest)
+	}
+
+	return nil
 }
 
 func Build() (*Context, error) {
@@ -32,4 +55,53 @@ func Build() (*Context, error) {
 		Config:   &conf,
 		Manifest: project,
 	}, nil
+}
+
+func backfillConsoleContext(man *manifest.ProjectManifest) error {
+	path := manifest.ContextPath()
+	ctx, err := manifest.FetchContext()
+	if err != nil {
+		ctx = manifest.NewContext()
+	}
+
+	console, ok := ctx.Configuration["console"]
+	if !ok {
+		console = map[string]interface{}{}
+	}
+
+	utils.Highlight("It looks like you cloned this repo before running plural up, we just need you to generate and give us a deploy key to continue\n")
+	utils.Highlight("If you want, you can use `plural crypto ssh-keygen` to generate a keypair to use as a deploy key as well\n\n")
+
+	var deployKey string
+	prompt := &survey.Input{
+		Message: "Select a file containing a read-only deploy key for this repo (use tab to list files in the directory):",
+		Default: "~/.ssh",
+		Suggest: func(toComplete string) []string {
+			path, err := homedir.Expand(toComplete)
+			if err != nil {
+				path = toComplete
+			}
+			files, _ := filepath.Glob(bundle.CleanPath(path) + "*")
+			return files
+		},
+	}
+
+	opts := []survey.AskOpt{survey.WithValidator(survey.Required)}
+	if err := survey.AskOne(prompt, &deployKey, opts...); err != nil {
+		return err
+	}
+
+	keyPath, err := homedir.Expand(deployKey)
+	if err != nil {
+		return err
+	}
+
+	contents, err := utils.ReadFile(keyPath)
+	if err != nil {
+		return err
+	}
+
+	console["private_key"] = contents
+	ctx.Configuration["console"] = console
+	return ctx.Write(path)
 }


### PR DESCRIPTION
## Summary
Currently the command will trip because the console context entry has likely not been set up, all we need is the pull cred, so setting that explicitly in a backfill function here.


## Test Plan
n/a

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.