### PR TITLE
fix: update goreleaser config and add build ci job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,8 +8,6 @@ plural.lock
 .golangci.yml
 docker-compose.yml
 *.md
-plural.lock
-Pluralfile
 renovate.json
 packer/
 hack/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -397,3 +397,59 @@ jobs:
         uses: golangci/golangci-lint-action@v4
         with:
           version: v1.54.2
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        include:
+          - os: ubuntu-latest
+            goos: linux
+          - os: macos-latest
+            goos: darwin
+          - os: windows-latest
+            goos: windows
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v4.1.0
+        with:
+          go-version-file: go.mod
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.18.1
+      - name: Setup SHA variable
+        shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Setup Cache
+        uses: actions/cache@v3.2.3
+        with:
+          path: dist/${{ matrix.goos }}
+          key: ${{ matrix.goos }}-${{ env.sha_short }}
+          enableCrossOsArchive: true
+      - name: Install Dependencies
+        if: matrix.goos == 'linux'
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install -y libwebkit2gtk-4.0-dev libgtk-3-dev
+      - name: Build web
+        shell: bash
+        run: make build-web
+      - name: GoReleaser (Build)
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: release --clean --split --timeout 90m
+        env:
+          CGO_LDFLAGS: "${{ matrix.goos == 'darwin' && '-framework UniformTypeIdentifiers' || '' }}"
+          GOOS: ${{ matrix.GOOS }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLAB_CLIENT_SECRET: ${{ secrets.GITLAB_CLIENT_SECRET }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -398,6 +398,7 @@ jobs:
         with:
           version: v1.54.2
   build:
+    name: GoReleaser build
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -437,9 +438,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libwebkit2gtk-4.0-dev libgtk-3-dev
-      - name: Build web
-        shell: bash
-        run: make build-web
       - name: GoReleaser (Build)
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,13 +15,13 @@ builds:
       - linux_amd64
       - linux_arm64
       - windows_amd64
-# TODO: Re-enable once fixed
-# Ref: https://github.com/golang/go/issues/51019
-#      - windows_arm64
+      # TODO: Re-enable once fixed
+      # Ref: https://github.com/golang/go/issues/51019
+      # - windows_arm64
       - darwin_amd64
       - darwin_arm64
     env:
-      - CGO_ENABLED=1
+      - CGO_ENABLED=0
     ldflags:
       - -s
       - -w
@@ -43,21 +43,21 @@ builds:
         env:
           - CGO_ENABLED=0
   # Build CLI binary without embedded UI for linux.
-  - id: plural-cli-console
-    targets:
-      - linux_amd64
-      - linux_arm64
-    ldflags:
-      - -s
-      - -w
-      - -X "github.com/pluralsh/plural-cli/cmd/plural.Version={{.Version}}"
-      - -X "github.com/pluralsh/plural-cli/cmd/plural.Commit={{.Commit}}"
-      - -X "github.com/pluralsh/plural-cli/cmd/plural.Date={{.Date}}"
-      - -X "github.com/pluralsh/plural-cli/pkg/scm.GitlabClientSecret={{.Env.GITLAB_CLIENT_SECRET}}"
-    tags: [ linux ]
-    env:
-      - CGO_ENABLED=0
-    binary: plural
+#  - id: plural-cli-console
+#    targets:
+#      - linux_amd64
+#      - linux_arm64
+#    ldflags:
+#      - -s
+#      - -w
+#      - -X "github.com/pluralsh/plural-cli/cmd/plural.Version={{.Version}}"
+#      - -X "github.com/pluralsh/plural-cli/cmd/plural.Commit={{.Commit}}"
+#      - -X "github.com/pluralsh/plural-cli/cmd/plural.Date={{.Date}}"
+#      - -X "github.com/pluralsh/plural-cli/pkg/scm.GitlabClientSecret={{.Env.GITLAB_CLIENT_SECRET}}"
+#    tags: [ linux ]
+#    env:
+#      - CGO_ENABLED=0
+#    binary: plural
 
 archives:
   - id: plural-cli
@@ -67,13 +67,13 @@ archives:
       {{- title .Os }}_
       {{- if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-  - id: plural-cli-console
-    builds: [ plural-cli-console ]
-    name_template: >-
-      {{ .ProjectName }}_console_{{ .Version }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
+#  - id: plural-cli-console
+#    builds: [ plural-cli-console ]
+#    name_template: >-
+#      {{ .ProjectName }}_console_{{ .Version }}_
+#      {{- title .Os }}_
+#      {{- if eq .Arch "386" }}i386
+#      {{- else }}{{ .Arch }}{{ end }}
 
 checksum:
   name_template: 'checksums.txt'

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ genmock: # generates mocks before running tests
 
 .PHONY: lint
 lint:
-	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.54.2 golangci-lint run
+	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.56.2 golangci-lint run
 
 .PHONY: delete-tag
 delete-tag:

--- a/dockerfiles/Dockerfile.cloud
+++ b/dockerfiles/Dockerfile.cloud
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.17 AS builder
+FROM golang:1.22-alpine3.19 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Update goreleaser config
  - Get rid of dedicated console builds since UI is disabled by default. 
  - Do not use `CGO_ENABLED` build as it is only required with embedded UI.
- Add build job to the CI to build all binaries with goreleaser without releasing. It should allow us to avoid this kind of issues in the future.
- Fix cloud image build

**NOTE**: We will need to rewire console to use standard binary (without `console` suffix)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
GH CI

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.