### PR TITLE
Get Namespace before creating

### DIFF
--- a/pkg/kubernetes/kube.go
+++ b/pkg/kubernetes/kube.go
@@ -326,7 +326,12 @@ func (k *kube) Apply(path string, force bool) error {
 
 func (k *kube) CreateNamespace(namespace string) error {
 	ctx := context.Background()
-	_, err := k.Kube.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
+	_, err := k.Kube.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err == nil {
+		return nil
+	}
+
+	_, err = k.Kube.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 			Labels: map[string]string{


### PR DESCRIPTION
## Summary

Some orgs will put admission webhooks on namespaces enforcing various label/annotation policies, checking if it exists after failed creates will bug because the admission controller will throw first causing the error to not be a not found error.  So we should get before create to properly upsert namespaces.

## Test Plan
n/a

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.