### PR TITLE
Don't use crap go yaml parser

### DIFF
--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/pluralsh/plural-cli/pkg/utils/pathing"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 func CopyFile(src, dest string) error {


### PR DESCRIPTION
## Summary

Nested objects become map[interface{}]interface{} which fails to then be json encoded, use k8s' internal one instead.

## Test Plan
local


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.