### PR TITLE
Agent install command broke when auth-less

### DIFF
--- a/cmd/plural/cd.go
+++ b/cmd/plural/cd.go
@@ -97,6 +97,9 @@ func (p *Plural) handleInstallDeploymentsOperator(c *cli.Context) error {
 		}
 	}
 
+	// we don't care if this fails to init as this command can be auth-less
+	_ = p.InitConsoleClient(consoleToken, consoleURL)
+
 	return p.doInstallOperator(c.String("url"), c.String("token"), c.String("values"))
 }
 
@@ -121,13 +124,12 @@ func (p *Plural) doInstallOperator(url, token, values string) error {
 	vals := map[string]interface{}{}
 	globalVals := map[string]interface{}{}
 
-	settings, err := p.ConsoleClient.GetGlobalSettings()
-	if err != nil {
-		return err
-	}
-	if settings != nil && settings.AgentHelmValues != nil {
-		if err := yaml.Unmarshal([]byte(*settings.AgentHelmValues), &globalVals); err != nil {
-			return err
+	if p.ConsoleClient != nil {
+		settings, err := p.ConsoleClient.GetGlobalSettings()
+		if err == nil && settings != nil && settings.AgentHelmValues != nil {
+			if err := yaml.Unmarshal([]byte(*settings.AgentHelmValues), &globalVals); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/pr/utils.go
+++ b/pkg/pr/utils.go
@@ -2,6 +2,7 @@ package pr
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/osteele/liquid"
 )
@@ -32,6 +33,11 @@ func replaceTo(from, to string, rep func(data []byte) ([]byte, error)) error {
 	if err != nil {
 		return err
 	}
+
+	if err := os.MkdirAll(filepath.Dir(to), 0755); err != nil {
+		return err
+	}
+
 	return os.WriteFile(to, resData, info.Mode())
 }
 


### PR DESCRIPTION
You can technically run `plural cd install` w/o authenticating to the console, but the new global settings fetch breaks that.  Make that code a bit more defensive

<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.