### PR TITLE
fix namespace creation for deployment operator

### DIFF
--- a/cmd/plural/bootstrap.go
+++ b/cmd/plural/bootstrap.go
@@ -252,7 +252,7 @@ func (p *Plural) handleCreateNamespace(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := p.CreateNamespace(name); err != nil {
+	if err := p.CreateNamespace(name, true); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			return nil
 		}

--- a/cmd/plural/cd.go
+++ b/cmd/plural/cd.go
@@ -116,7 +116,7 @@ func (p *Plural) doInstallOperator(url, token, values string) error {
 	if err != nil {
 		return err
 	}
-	err = p.Kube.CreateNamespace(console.OperatorNamespace)
+	err = p.Kube.CreateNamespace(console.OperatorNamespace, false)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}


### PR DESCRIPTION
## Summary
During the deployment operator installation we create the namespace with the label: `app.kubernetes.io/managed-by`. If there is a plural operator then it will add:
```
  imagePullSecrets:
  - name: plural-creds
```
to each pod. For the CD we don't have `plural-creds` secret.
This label is needed for the CAPI installation. 

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.