### PR TITLE
Fallback to reinstall in `cd clusters bootstrap` command

### DIFF
--- a/pkg/console/errors/like.go
+++ b/pkg/console/errors/like.go
@@ -1,0 +1,32 @@
+package errors
+
+import (
+	"errors"
+	"strings"
+
+	client "github.com/Yamashou/gqlgenc/clientv2"
+)
+
+func Like(err error, msg string) bool {
+	if err == nil {
+		return false
+	}
+
+	errorResponse := new(client.ErrorResponse)
+	ok := errors.As(err, &errorResponse)
+	if !ok {
+		return false
+	}
+
+	return isLike(errorResponse, msg)
+}
+
+func isLike(err *client.ErrorResponse, msg string) bool {
+	for _, g := range *err.GqlErrors {
+		if strings.Contains(g.Message, msg) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary
It's kind of annoying having to know to either run `plural cd bootstrap` or `plural cd reinstall` etc.  Trying to move it all into a functional single-command flow here.


## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.