### PR TITLE
Need to use consoleToken when running gen-backend

### DIFF
--- a/cmd/plural/cd_stacks.go
+++ b/cmd/plural/cd_stacks.go
@@ -73,7 +73,7 @@ func (p *Plural) handleGenerateBackend(_ *cli.Context) error {
 		LockAddress:   lo.FromPtr(stateUrls.Lock),
 		UnlockAddress: lo.FromPtr(stateUrls.Unlock),
 		Actor:         cfg.Email,
-		DeployToken:   cfg.Token,
+		DeployToken:   consoleToken,
 	}, dir)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
The plural token doesn't auth to your console instance


## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.