### PR TITLE
Proper generation of ext urls

### DIFF
--- a/cmd/plural/cd_clusters.go
+++ b/cmd/plural/cd_clusters.go
@@ -401,7 +401,13 @@ func (p *Plural) reinstallOperator(c *cli.Context, id, handle *string) error {
 		return err
 	}
 
-	url := fmt.Sprintf("%s/ext/gql", p.ConsoleClient.Url())
+	url := p.ConsoleClient.ExtUrl()
+	if cluster, err := p.ConsoleClient.GetCluster(id, handle); err == nil {
+		if agentUrl, err := p.ConsoleClient.AgentUrl(cluster.ID); err == nil {
+			url = agentUrl
+		}
+	}
+
 	return p.doInstallOperator(url, deployToken, c.String("values"))
 }
 
@@ -446,8 +452,12 @@ func (p *Plural) handleClusterBootstrap(c *cli.Context) error {
 		return fmt.Errorf("could not fetch deploy token from cluster")
 	}
 
+	url := p.ConsoleClient.ExtUrl()
+	if agentUrl, err := p.ConsoleClient.AgentUrl(existing.CreateCluster.ID); err == nil {
+		url = agentUrl
+	}
+
 	deployToken := *existing.CreateCluster.DeployToken
-	url := fmt.Sprintf("%s/ext/gql", p.ConsoleClient.Url())
 	utils.Highlight("installing agent on %s with url %s and initial deploy token %s\n", c.String("name"), p.ConsoleClient.Url(), deployToken)
 	return p.doInstallOperator(url, deployToken, c.String("values"))
 }

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/packethost/packngo v0.29.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pluralsh/cluster-api-migration v0.2.16
-	github.com/pluralsh/console-client-go v0.9.0
+	github.com/pluralsh/console-client-go v0.9.1
 	github.com/pluralsh/gqlclient v1.11.0
 	github.com/pluralsh/plural-operator v0.5.5
 	github.com/pluralsh/polly v0.1.8

--- a/go.sum
+++ b/go.sum
@@ -1885,6 +1885,8 @@ github.com/pluralsh/cluster-api-migration v0.2.16 h1:MQGrLQAhGSSpyjEDamhnJZaQ8Mk
 github.com/pluralsh/cluster-api-migration v0.2.16/go.mod h1:24PjMsYv3vSlUiYw7BeUQ0GAtK0Jk2B1iwh35WGQLx8=
 github.com/pluralsh/console-client-go v0.9.0 h1:2rCPLVeooSV6WKfIKxqssloE1e6AkdP6LWwueQQlBsg=
 github.com/pluralsh/console-client-go v0.9.0/go.mod h1:eyCiLA44YbXiYyJh8303jk5JdPkt9McgCo5kBjk4lKo=
+github.com/pluralsh/console-client-go v0.9.1 h1:o2khvyRu/d3ndehbX02CjnMbU6i0smhulhe0OYnp8yE=
+github.com/pluralsh/console-client-go v0.9.1/go.mod h1:eyCiLA44YbXiYyJh8303jk5JdPkt9McgCo5kBjk4lKo=
 github.com/pluralsh/controller-reconcile-helper v0.0.4 h1:1o+7qYSyoeqKFjx+WgQTxDz4Q2VMpzprJIIKShxqG0E=
 github.com/pluralsh/controller-reconcile-helper v0.0.4/go.mod h1:AfY0gtteD6veBjmB6jiRx/aR4yevEf6K0M13/pGan/s=
 github.com/pluralsh/gqlclient v1.11.0 h1:FfXW7FiEJLHOfTAa7NxDb8jb3aMZNIpCAcG+bg8uHYA=

--- a/pkg/console/clusters.go
+++ b/pkg/console/clusters.go
@@ -37,6 +37,19 @@ func (c *consoleClient) GetCluster(clusterId, clusterName *string) (*consoleclie
 	return result.Cluster, nil
 }
 
+func (c *consoleClient) AgentUrl(id string) (string, error) {
+	res, err := c.client.GetAgentURL(c.ctx, id)
+	if err != nil {
+		return "", err
+	}
+
+	if res == nil {
+		return "", fmt.Errorf("cluster not found")
+	}
+
+	return lo.FromPtr(res.Cluster.AgentURL), nil
+}
+
 func (c *consoleClient) GetDeployToken(clusterId, clusterName *string) (string, error) {
 	res, err := c.client.GetClusterWithToken(c.ctx, clusterId, clusterName)
 	if err != nil {

--- a/pkg/test/mocks/ConsoleClient.go
+++ b/pkg/test/mocks/ConsoleClient.go
@@ -12,6 +12,34 @@ type ConsoleClient struct {
 	mock.Mock
 }
 
+// AgentUrl provides a mock function with given fields: id
+func (_m *ConsoleClient) AgentUrl(id string) (string, error) {
+	ret := _m.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AgentUrl")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(id)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CloneService provides a mock function with given fields: clusterId, serviceId, serviceName, clusterName, attributes
 func (_m *ConsoleClient) CloneService(clusterId string, serviceId *string, serviceName *string, clusterName *string, attributes gqlclient.ServiceCloneAttributes) (*gqlclient.ServiceDeploymentFragment, error) {
 	ret := _m.Called(clusterId, serviceId, serviceName, clusterName, attributes)
@@ -313,6 +341,24 @@ func (_m *ConsoleClient) DetachCluster(id string) error {
 		r0 = rf(id)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ExtUrl provides a mock function with given fields:
+func (_m *ConsoleClient) ExtUrl() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExtUrl")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0


### PR DESCRIPTION
## Summary

When a user wants to split the graph between public/private, we're too blase about generating urls.  This is a bit more precise and ensures the agent is configured correctly from the cli. (Ideally we just grab this from the deployment operator service secret tbh)

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.