### PR TITLE
Prune unneeded resources post `plural up`

### DIFF
--- a/cmd/plural/up.go
+++ b/cmd/plural/up.go
@@ -32,8 +32,6 @@ func (p *Plural) handleUp(c *cli.Context) error {
 		return err
 	}
 
-	defer ctx.Cleanup()
-
 	if err := ctx.Backfill(); err != nil {
 		return err
 	}

--- a/pkg/up/generate.go
+++ b/pkg/up/generate.go
@@ -21,7 +21,7 @@ func (ctx *Context) Cleanup() {
 
 func (ctx *Context) Generate() error {
 	if !utils.Exists("./bootstrap") {
-		if err := git.BranchedSubmodule("https://github.com/pluralsh/bootstrap.git", "stacks-support"); err != nil {
+		if err := git.BranchedSubmodule("https://github.com/pluralsh/bootstrap.git", "refactored-up"); err != nil {
 			return err
 		}
 	}
@@ -31,11 +31,11 @@ func (ctx *Context) Generate() error {
 		{from: "./bootstrap/charts/runtime/values.yaml.tpl", to: "./helm-values/runtime.yaml", overwrite: true},
 		{from: "./bootstrap/helm/certmanager.yaml", to: "./helm-values/certmanager.yaml", overwrite: true},
 		{from: "./bootstrap/helm/flux.yaml", to: "./helm-values/flux.yaml", overwrite: true},
-		{from: fmt.Sprintf("./bootstrap/templates/providers/bootstrap/%s.tf", prov), to: "clusters/provider.tf"},
-		{from: fmt.Sprintf("./bootstrap/templates/setup/providers/%s.tf", prov), to: "clusters/mgmt.tf"},
-		{from: "./bootstrap/templates/setup/console.tf", to: "clusters/console.tf"},
-		{from: fmt.Sprintf("./bootstrap/templates/providers/apps/%s.tf", prov), to: "apps/terraform/provider.tf"},
-		{from: "./bootstrap/templates/setup/cd.tf", to: "apps/terraform/cd.tf"},
+		{from: fmt.Sprintf("./bootstrap/templates/providers/bootstrap/%s.tf", prov), to: "terraform/mgmt/provider.tf"},
+		{from: fmt.Sprintf("./bootstrap/templates/setup/providers/%s.tf", prov), to: "terraform/mgmt/mgmt.tf"},
+		{from: "./bootstrap/templates/setup/console.tf", to: "terraform/mgmt/console.tf"},
+		{from: fmt.Sprintf("./bootstrap/templates/providers/apps/%s.tf", prov), to: "terraform/apps/provider.tf"},
+		{from: "./bootstrap/templates/setup/cd.tf", to: "terraform/apps/cd.tf"},
 		{from: "./bootstrap/README.md", to: "README.md", overwrite: true},
 	}
 
@@ -52,7 +52,7 @@ func (ctx *Context) Generate() error {
 
 	copies := []templatePair{
 		{from: "./bootstrap/terraform/modules/clusters", to: "terraform/modules/clusters"},
-		{from: fmt.Sprintf("./bootstrap/terraform/clouds/%s", prov), to: "terraform/modules/mgmt"},
+		{from: fmt.Sprintf("./bootstrap/terraform/clouds/%s", prov), to: "terraform/mgmt/cluster"},
 		{from: "./bootstrap/apps/repositories", to: "apps/repositories"},
 		{from: "./bootstrap/apps/services", to: "apps/services"},
 		{from: "./bootstrap/templates", to: "templates"},

--- a/pkg/up/prune.go
+++ b/pkg/up/prune.go
@@ -1,0 +1,48 @@
+package up
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/pluralsh/plural-cli/pkg/utils"
+	"github.com/pluralsh/plural-cli/pkg/utils/git"
+)
+
+func (ctx *Context) Prune() error {
+	utils.Highlight("\nCleaning up unneeded resources...\n\n")
+	repoRoot, err := git.Root()
+	if err != nil {
+		return err
+	}
+
+	toRemove := []string{
+		"null_resource.console",
+		"helm_release.certmanager",
+		"helm_release.flux",
+		"helm_release.runtime",
+		"helm_release.console",
+	}
+
+	for _, field := range toRemove {
+		if err := stateRm("./terraform/mgmt", field); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Remove("./terraform/mgmt/console.tf"); err != nil {
+		return err
+	}
+
+	_ = os.RemoveAll("./terraform/apps")
+	ctx.Cleanup()
+
+	return git.Sync(repoRoot, "Post-setup resource cleanup", true)
+}
+
+func stateRm(dir, field string) error {
+	cmd := exec.Command("terraform", "state", "rm", field)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}


### PR DESCRIPTION
We use helm_releases and set up a largely unnecessary `apps` stack as part of `plural up`.  We can just eliminate them to save complexity once the management cluster is up, and it will also make it easier to move the management cluster into a sack seamlessly.

## Test Plan
ran `plural up` with a local compile

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.