### PR TITLE
enhancement: remove /**/terraform/**/main.tf from default encryption filters

### DIFF
--- a/pkg/common/crypto.go
+++ b/pkg/common/crypto.go
@@ -19,8 +19,6 @@ const Gitattributes = `/**/helm/**/values.yaml filter=plural-crypt diff=plural-c
 /**/helm/**/values.yaml* filter=plural-crypt diff=plural-crypt
 /**/helm/**/README.md* filter=plural-crypt diff=plural-crypt
 /**/helm/**/default-values.yaml* filter=plural-crypt diff=plural-crypt
-/**/terraform/**/main.tf filter=plural-crypt diff=plural-crypt
-/**/terraform/**/main.tf* filter=plural-crypt diff=plural-crypt
 /**/manifest.yaml filter=plural-crypt diff=plural-crypt
 /**/output.yaml filter=plural-crypt diff=plural-crypt
 /diffs/**/* filter=plural-crypt diff=plural-crypt

--- a/pkg/common/crypto.go
+++ b/pkg/common/crypto.go
@@ -58,12 +58,16 @@ func CryptoInit(c *cli.Context) error {
 		}
 	}
 
-	if err := utils.WriteFile(GitAttributesFile, []byte(Gitattributes)); err != nil {
-		return err
+	if !utils.Exists(GitAttributesFile) {
+		if err := utils.WriteFile(GitAttributesFile, []byte(Gitattributes)); err != nil {
+			return err
+		}
 	}
 
-	if err := utils.WriteFile(GitIgnoreFile, []byte(Gitignore)); err != nil {
-		return err
+	if !utils.Exists(GitIgnoreFile) {
+		if err := utils.WriteFile(GitIgnoreFile, []byte(Gitignore)); err != nil {
+			return err
+		}
 	}
 
 	_, err := crypto.Build()


### PR DESCRIPTION
It removes `/**/terraform/**/main.tf` and also `/**/terraform/**/main.tf*` from default enctryption filters.