### PR TITLE
Revert main plural-cli name template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,7 @@ builds:
 archives:
   - id: plural-cli
     builds: [plural-cli]
-    name_template: '{{ .Binary }}_{{ .Version }}_{{- title .Os -}}_{{- if eq .Arch "386" -}}i386{{- else -}}{{ .Arch }}{{- end -}}'
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{- title .Os -}}_{{- if eq .Arch "386" -}}i386{{- else -}}{{ .Arch }}{{- end -}}'
   - id: plrlctl
     builds: [plrlctl]
     name_template: '{{ .Binary }}_{{ .Version }}_{{- title .Os -}}_{{- if eq .Arch "386" -}}i386{{- else -}}{{ .Arch }}{{- end -}}'


### PR DESCRIPTION
`setup-plural` breaks with the prior change