### PR TITLE
better streamline plural up --cloud

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,73 +86,73 @@ jobs:
       #     docker buildx stop ${{ steps.builder.outputs.name }}
       #     sleep 10
       #     docker buildx rm ${{ steps.builder.outputs.name }}
-  cloud:
-    name: Build cloud image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-      packages: 'write'
-      security-events: write
-      actions: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ghcr.io/pluralsh/plural-cli-cloud
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=sha
-            type=ref,event=pr
-            type=ref,event=branch
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GHCR
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get current date
-        id: date
-        run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%S%z')" >> $GITHUB_OUTPUT
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./dockerfiles/Dockerfile.cloud
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          # cache-from: type=gha
-          # cache-to: type=gha,mode=max
-          build-args: |
-            APP_VSN=dev
-            APP_COMMIT=${{ github.sha }}
-            APP_DATE=${{ steps.date.outputs.date }}
-      - name: Run Trivy vulnerability scanner on cli cloud image
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'image'
-          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
-          hide-progress: false
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          scanners: 'vuln'
-          timeout: 10m
-          ignore-unfixed: true
-           #severity: 'CRITICAL,HIGH'
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: 'trivy-results.sarif'
+  # cloud:
+  #   name: Build cloud image
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: 'read'
+  #     id-token: 'write'
+  #     packages: 'write'
+  #     security-events: write
+  #     actions: read
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #     - name: Docker meta
+  #       id: meta
+  #       uses: docker/metadata-action@v4
+  #       with:
+  #         # list of Docker images to use as base name for tags
+  #         images: |
+  #           ghcr.io/pluralsh/plural-cli-cloud
+  #         # generate Docker tags based on the following events/attributes
+  #         tags: |
+  #           type=sha
+  #           type=ref,event=pr
+  #           type=ref,event=branch
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
+  #     - name: Login to GHCR
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Get current date
+  #       id: date
+  #       run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%S%z')" >> $GITHUB_OUTPUT
+  #     - uses: docker/build-push-action@v6
+  #       with:
+  #         context: .
+  #         file: ./dockerfiles/Dockerfile.cloud
+  #         push: true
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         labels: ${{ steps.meta.outputs.labels }}
+  #         platforms: linux/amd64,linux/arm64
+  #         # cache-from: type=gha
+  #         # cache-to: type=gha,mode=max
+  #         build-args: |
+  #           APP_VSN=dev
+  #           APP_COMMIT=${{ github.sha }}
+  #           APP_DATE=${{ steps.date.outputs.date }}
+  #     - name: Run Trivy vulnerability scanner on cli cloud image
+  #       uses: aquasecurity/trivy-action@master
+  #       with:
+  #         scan-type: 'image'
+  #         image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+  #         hide-progress: false
+  #         format: 'sarif'
+  #         output: 'trivy-results.sarif'
+  #         scanners: 'vuln'
+  #         timeout: 10m
+  #         ignore-unfixed: true
+  #          #severity: 'CRITICAL,HIGH'
+  #     - name: Upload Trivy scan results to GitHub Security tab
+  #       uses: github/codeql-action/upload-sarif@v2
+  #       with:
+  #         sarif_file: 'trivy-results.sarif'
   dind:
     name: Build dind image
     runs-on: ubuntu-latest

--- a/cmd/command/cd/cd_clusters.go
+++ b/cmd/command/cd/cd_clusters.go
@@ -118,19 +118,12 @@ func (p *Plural) cdClusterCommands() []cli.Command {
 }
 
 func (p *Plural) handleListClusters(_ *cli.Context) error {
-	if err := p.InitConsoleClient(consoleToken, consoleURL); err != nil {
-		return err
-	}
-
-	clusters, err := p.ConsoleClient.ListClusters()
+	clusters, err := p.ListClusters()
 	if err != nil {
 		return err
 	}
-	if clusters == nil {
-		return fmt.Errorf("returned objects list [ListClusters] is nil")
-	}
 	headers := []string{"Id", "Name", "Handle", "Version", "Provider"}
-	return utils.PrintTable(clusters.Clusters.Edges, headers, func(cl *gqlclient.ClusterEdgeFragment) ([]string, error) {
+	return utils.PrintTable(clusters, headers, func(cl *gqlclient.ClusterEdgeFragment) ([]string, error) {
 		provider := ""
 		if cl.Node.Provider != nil {
 			provider = cl.Node.Provider.Name
@@ -145,6 +138,20 @@ func (p *Plural) handleListClusters(_ *cli.Context) error {
 		}
 		return []string{cl.Node.ID, cl.Node.Name, handle, version, provider}, nil
 	})
+}
+
+func (p *Plural) ListClusters() ([]*gqlclient.ClusterEdgeFragment, error) {
+	if err := p.InitConsoleClient(consoleToken, consoleURL); err != nil {
+		return nil, err
+	}
+	clusters, err := p.ConsoleClient.ListClusters()
+	if err != nil {
+		return nil, err
+	}
+	if clusters == nil {
+		return nil, fmt.Errorf("returned objects list [ListClusters] is nil")
+	}
+	return clusters.Clusters.Edges, nil
 }
 
 func (p *Plural) GetClusterId(handle string) (string, string, error) {

--- a/cmd/command/up/up.go
+++ b/cmd/command/up/up.go
@@ -122,7 +122,7 @@ func (p *Plural) handleUp(c *cli.Context) error {
 
 func getCluster(cd *cd.Plural) (id string, name string, err error) {
 	if cd == nil {
-		return "", "", fmt.Errorf("please provide a plural client")
+		return "", "", fmt.Errorf("your CLI is not logged into Plural, try running `plural login` to generate local credentials")
 	}
 	clusters, err := cd.ListClusters()
 	if err != nil {

--- a/cmd/command/up/up.go
+++ b/cmd/command/up/up.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/pluralsh/plural-cli/cmd/command/cd"
 	"github.com/pluralsh/plural-cli/pkg/client"
 	"github.com/pluralsh/plural-cli/pkg/common"
@@ -81,11 +82,10 @@ func (p *Plural) handleUp(c *cli.Context) error {
 	}
 
 	if c.Bool("cloud") {
-		id, name, err := cd.GetClusterId("mgmt")
+		id, name, err := getCluster(cd)
 		if err != nil {
 			return err
 		}
-
 		ctx.ImportCluster = lo.ToPtr(id)
 		ctx.CloudCluster = name
 	}
@@ -118,4 +118,32 @@ func (p *Plural) handleUp(c *cli.Context) error {
 	utils.Success("Finished setting up your management cluster!\n")
 	utils.Highlight("Feel free to use terraform as you normally would, and leverage the gitops setup we've generated in the apps/ subfolder\n")
 	return nil
+}
+
+func getCluster(cd *cd.Plural) (id string, name string, err error) {
+	if cd == nil {
+		return "", "", fmt.Errorf("please provide a plural client")
+	}
+	clusters, err := cd.ListClusters()
+	if err != nil {
+		return "", "", err
+	}
+
+	clusterNames := []string{}
+	clusterMap := map[string]string{}
+
+	for _, cluster := range clusters {
+		clusterNames = append(clusterNames, cluster.Node.Name)
+		clusterMap[cluster.Node.Name] = cluster.Node.ID
+	}
+
+	prompt := &survey.Select{
+		Message: "Select one of the following clusters:",
+		Options: clusterNames,
+	}
+	if err = survey.AskOne(prompt, &name, survey.WithValidator(survey.Required)); err != nil {
+		return
+	}
+	id = clusterMap[name]
+	return
 }

--- a/dockerfiles/Dockerfile.cloud
+++ b/dockerfiles/Dockerfile.cloud
@@ -31,13 +31,13 @@ FROM alpine:3.17.2 as tools
 ARG TARGETARCH
 
 # renovate: datasource=github-releases depName=helm/helm
-ENV HELM_VERSION=v3.10.3
+ENV HELM_VERSION=v3.15.1
 
 # renovate: datasource=github-releases depName=hashicorp/terraform
-ENV TERRAFORM_VERSION=v1.2.9
+ENV TERRAFORM_VERSION=v1.9.7
 
 # renovate: datasource=github-tags depName=kubernetes/kubernetes
-ENV KUBECTL_VERSION=v1.25.5
+ENV KUBECTL_VERSION=v1.30.0
 
 RUN apk add --update --no-cache curl ca-certificates unzip wget openssl build-base && \
     curl -L https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz | tar xvz && \

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -118,14 +118,16 @@ func Read(path string) (man *Manifest, err error) {
 	return
 }
 
-func (pMan *ProjectManifest) Configure(cloud bool) Writer {
+func (pMan *ProjectManifest) Configure(cloud bool, cluster string) Writer {
 	utils.Highlight("\nLet's get some final information about your workspace set up\n\n")
 
-	res, _ := utils.ReadAlphaNum("Give us a unique, memorable string to use for bucket naming, eg an abbreviation for your company: ")
-	pMan.BucketPrefix = res
-	pMan.Bucket = fmt.Sprintf("%s-tf-state", res)
+	pMan.BucketPrefix = cluster
+	pMan.Bucket = fmt.Sprintf("plrl-cloud-%s", cluster)
 
 	if !cloud {
+		res, _ := utils.ReadAlphaNum("Give us a unique, memorable string to use for bucket naming, eg an abbreviation for your company: ")
+		pMan.BucketPrefix = res
+		pMan.Bucket = fmt.Sprintf("%s-tf-state", res)
 		if err := pMan.ConfigureNetwork(); err != nil {
 			return nil
 		}

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -183,7 +183,7 @@ func mkAzure(conf config.Config) (prov *AzureProvider, err error) {
 		Context:  prov.Context(),
 		Owner:    &manifest.Owner{Email: conf.Email, Endpoint: conf.Endpoint},
 	}
-	prov.writer = projectManifest.Configure(cloudFlag)
+	prov.writer = projectManifest.Configure(cloudFlag, prov.Cluster())
 	prov.bucket = projectManifest.Bucket
 	return
 }

--- a/pkg/provider/equinix.go
+++ b/pkg/provider/equinix.go
@@ -108,7 +108,7 @@ func mkEquinix(conf config.Config) (provider *EQUINIXProvider, err error) {
 		Owner:    &manifest.Owner{Email: conf.Email, Endpoint: conf.Endpoint},
 	}
 
-	provider.writer = projectManifest.Configure(cloudFlag)
+	provider.writer = projectManifest.Configure(cloudFlag, provider.Cluster())
 	provider.bucket = projectManifest.Bucket
 	return
 }

--- a/pkg/provider/gcp.go
+++ b/pkg/provider/gcp.go
@@ -160,7 +160,7 @@ func mkGCP(conf config.Config) (provider *GCPProvider, err error) {
 		Owner:    &manifest.Owner{Email: conf.Email, Endpoint: conf.Endpoint},
 	}
 
-	provider.writer = projectManifest.Configure(cloudFlag)
+	provider.writer = projectManifest.Configure(cloudFlag, provider.Cluster())
 	provider.bucket = projectManifest.Bucket
 	return
 }

--- a/pkg/provider/kind.go
+++ b/pkg/provider/kind.go
@@ -62,7 +62,7 @@ func mkKind(conf config.Config) (provider *KINDProvider, err error) {
 		Owner:    &manifest.Owner{Email: conf.Email, Endpoint: conf.Endpoint},
 	}
 
-	provider.writer = projectManifest.Configure(cloudFlag)
+	provider.writer = projectManifest.Configure(cloudFlag, provider.Cluster())
 	provider.bucket = projectManifest.Bucket
 	return
 }

--- a/pkg/provider/linode.go
+++ b/pkg/provider/linode.go
@@ -87,7 +87,7 @@ func mkLinode(conf config.Config) (provider *LinodeProvider, err error) {
 		Owner:    &manifest.Owner{Email: conf.Email, Endpoint: conf.Endpoint},
 	}
 
-	provider.writer = projectManifest.Configure(cloudFlag)
+	provider.writer = projectManifest.Configure(cloudFlag, provider.Cluster())
 	provider.bucket = projectManifest.Bucket
 	return
 }


### PR DESCRIPTION
## Summary
 - replace the cluster name field with querying all the console instances for a user, using a select to choose the one they want to use, and use that name for the cluster name

 - no longer ask for the az spread (just chose one as a default and ignore)

 - make the bucket prefix automatically plrl-cloud-${name}.

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.