### PR TITLE
Add full porcelain status to `pr contracts --validate`

### DIFF
--- a/cmd/command/pr/pr.go
+++ b/cmd/command/pr/pr.go
@@ -184,7 +184,13 @@ func handlePrContracts(c *cli.Context) error {
 		}
 
 		if len(changes) > 0 {
-			utils.Highlight("Contracts failed due to local git changes, displaying below ===>\n\n")
+			utils.Highlight("Contracts failed due to local git changes, all changed files ===>\n\n")
+			status, err := git.Status()
+			if err != nil {
+				return err
+			}
+			fmt.Println(status)
+			utils.Highlight("Git diff output===>\n")
 			if err := git.PrintDiff(); err != nil {
 				return err
 			}

--- a/pkg/utils/git/workspace.go
+++ b/pkg/utils/git/workspace.go
@@ -20,3 +20,7 @@ func Modified() ([]string, error) {
 
 	return result, nil
 }
+
+func Status() (string, error) {
+	return GitRaw("status", "--porcelain")
+}


### PR DESCRIPTION
Apparently git diff doesn't dump out the details of new files (no idea why not).  This will allow the command output to at least show that.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.