### PR TITLE
feat: allow templating source field in pr automation

### DIFF
--- a/pkg/pr/creates.go
+++ b/pkg/pr/creates.go
@@ -21,6 +21,9 @@ func applyCreates(creates *CreateSpec, ctx map[string]interface{}) error {
 		if tpl.External {
 			source = filepath.Join(creates.ExternalDir, source)
 		}
+		if templatedSource, err := templateReplacement([]byte(source), ctx); err == nil {
+			source = string(templatedSource)
+		}
 
 		destPath := []byte(tpl.Destination)
 		dest, err := templateReplacement(destPath, ctx)


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Small update to allow pr automation to template `source` field under `creates`.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.