### PR TITLE
feat: add support for glob pattern to the prautomation->deletes->files

### DIFF
--- a/pkg/pr/deletes.go
+++ b/pkg/pr/deletes.go
@@ -15,7 +15,7 @@ func applyDeletes(deletes *DeleteSpec, ctx map[string]interface{}) error {
 			dest = []byte(f)
 		}
 
-		if err := os.Remove(string(dest)); err != nil {
+		if err := removeMatches(string(dest)); err != nil {
 			return err
 		}
 	}

--- a/pkg/pr/utils.go
+++ b/pkg/pr/utils.go
@@ -40,3 +40,18 @@ func replaceTo(from, to string, rep func(data []byte) ([]byte, error)) error {
 func replaceInPlace(path string, rep func(data []byte) ([]byte, error)) error {
 	return replaceTo(path, path, rep)
 }
+
+func removeMatches(glob string) error {
+	matches, err := filepath.Glob(glob)
+	if err != nil {
+		return err
+	}
+
+	for _, match := range matches {
+		if err := os.Remove(match); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Ref: [PROD-3014](https://linear.app/pluralsh/issue/PROD-3014/support-file-globs-in-deletes-for-plural-template-pr)


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally with some basic glob patterns and direct paths, i.e.:
- /dir/**/*.yaml
- /path/file.yaml

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.