### PR TITLE
fix: support multiline regexes in processRegexReplacements

### DIFF
--- a/pkg/pr/updates.go
+++ b/pkg/pr/updates.go
@@ -2,13 +2,13 @@ package pr
 
 import (
 	"bytes"
-	"io/fs"
-	"path/filepath"
-	"regexp"
-
 	"dario.cat/mergo"
 	"github.com/samber/lo"
 	"gopkg.in/yaml.v3"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"strings"
 )
 
 func applyUpdates(updates *UpdateSpec, ctx map[string]interface{}) error {
@@ -75,13 +75,7 @@ func processRegexReplacements(replacements []RegexReplacement, ctx map[string]in
 			if err != nil {
 				rx = []byte(replacement.Regex)
 			}
-
-			r, err := regexp.Compile(string(rx))
-			if err != nil {
-				return data, err
-			}
-
-			return r.ReplaceAll(data, replaceWith), nil
+			return replaceMultiline(rx, replaceWith, data)
 		}
 
 		dest, err := templateReplacement([]byte(replacement.File), ctx)
@@ -95,6 +89,24 @@ func processRegexReplacements(replacements []RegexReplacement, ctx map[string]in
 	}
 
 	return nil
+}
+
+// replaceMultiline applies regex-based replacements on a multiline string
+func replaceMultiline(pattern, replacement, text []byte) ([]byte, error) {
+	// Replace all newlines with a unique placeholder
+	placeholder := "__NL__"
+	flattenedText := strings.ReplaceAll(string(text), "\n", placeholder)
+
+	// Apply the regex replacement on the flattened text
+	re, err := regexp.Compile(string(pattern))
+	if err != nil {
+		return nil, err
+	}
+	flattenedText = re.ReplaceAllString(flattenedText, string(replacement))
+
+	// Revert the placeholder back to newlines
+	finalText := strings.ReplaceAll(flattenedText, placeholder, "\n")
+	return []byte(finalText), nil
 }
 
 func processYamlOverlays(overlays []YamlOverlay, ctx map[string]interface{}) error {


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
Fix the `plural pr template` command. It doesn't support multiline regexes in processRegexReplacements

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.