### PR TITLE
custom helm chart url

### DIFF
--- a/cmd/command/cd/cd.go
+++ b/cmd/command/cd/cd.go
@@ -78,6 +78,7 @@ func Commands(clients client.Plural, helmConfiguration *action.Configuration) []
 				cli.StringFlag{Name: "url", Usage: "console url", Required: true},
 				cli.StringFlag{Name: "token", Usage: "deployment token", Required: true},
 				cli.StringFlag{Name: "values", Usage: "values file to use for the deployment agent helm chart", Required: false},
+				cli.StringFlag{Name: "chart-loc", Usage: "URL or filepath of helm chart tar file. Use if not wanting to install helm chart from default plural repository.", Required: false},
 				cli.BoolFlag{Name: "force", Usage: "ignore checking if the current cluster is correct"},
 			},
 		},
@@ -136,7 +137,7 @@ func (p *Plural) handleInstallDeploymentsOperator(c *cli.Context) error {
 	// we don't care if this fails to init as this command can be auth-less
 	_ = p.InitConsoleClient(consoleToken, consoleURL)
 
-	return p.DoInstallOperator(c.String("url"), c.String("token"), c.String("values"))
+	return p.DoInstallOperator(c.String("url"), c.String("token"), c.String("values"), c.String("chart-loc"))
 }
 
 func (p *Plural) handleUninstallOperator(_ *cli.Context) error {

--- a/cmd/command/cd/cd_clusters.go
+++ b/cmd/command/cd/cd_clusters.go
@@ -98,6 +98,7 @@ func (p *Plural) cdClusterCommands() []cli.Command {
 				cli.StringFlag{Name: "name", Usage: "The name you'll give the cluster", Required: true},
 				cli.StringFlag{Name: "handle", Usage: "optional handle for the cluster"},
 				cli.StringFlag{Name: "values", Usage: "values file to use for the deployment agent helm chart", Required: false},
+				cli.StringFlag{Name: "chart-loc", Usage: "URL or filepath of helm chart tar file. Use if not wanting to install helm chart from default plural repository.", Required: false},
 				cli.StringFlag{Name: "project", Usage: "the project this cluster will belong to", Required: false},
 				cli.StringSliceFlag{
 					Name:  "tag",
@@ -110,6 +111,7 @@ func (p *Plural) cdClusterCommands() []cli.Command {
 			Action: common.LatestVersion(p.handleClusterReinstall),
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "values", Usage: "values file to use for the deployment agent helm chart", Required: false},
+				cli.StringFlag{Name: "chart-loc", Usage: "URL or filepath of helm chart tar file. Use if not wanting to install helm chart from default plural repository.", Required: false},
 			},
 			Usage:     "reinstalls the deployment operator into a cluster",
 			ArgsUsage: "@{cluster-handle}",
@@ -412,7 +414,7 @@ func (p *Plural) handleClusterReinstall(c *cli.Context) error {
 	}
 
 	id, name := common.GetIdAndName(handle)
-	return p.ReinstallOperator(c, id, name)
+	return p.ReinstallOperator(c, id, name, c.String("chart-loc"))
 }
 
 func (p *Plural) handleClusterBootstrap(c *cli.Context) error {
@@ -458,7 +460,7 @@ func (p *Plural) handleClusterBootstrap(c *cli.Context) error {
 			if attrs.Handle != nil {
 				handle = attrs.Handle
 			}
-			return p.ReinstallOperator(c, nil, handle)
+			return p.ReinstallOperator(c, nil, handle, c.String("chart-loc"))
 		}
 
 		return err
@@ -475,5 +477,5 @@ func (p *Plural) handleClusterBootstrap(c *cli.Context) error {
 
 	deployToken := *existing.CreateCluster.DeployToken
 	utils.Highlight("installing agent on %s with url %s\n", c.String("name"), p.ConsoleClient.Url())
-	return p.DoInstallOperator(url, deployToken, c.String("values"))
+	return p.DoInstallOperator(url, deployToken, c.String("values"), c.String("chart-loc"))
 }

--- a/cmd/command/edge/bootstrap.go
+++ b/cmd/command/edge/bootstrap.go
@@ -56,7 +56,7 @@ func (p *Plural) handleEdgeBootstrap(c *cli.Context) error {
 	if agentUrl, err := p.ConsoleClient.AgentUrl(cluster.CreateCluster.ID); err == nil {
 		url = agentUrl
 	}
-	return p.DoInstallOperator(url, *cluster.CreateCluster.DeployToken, "")
+	return p.DoInstallOperator(url, *cluster.CreateCluster.DeployToken, "", c.String("chart-loc"))
 }
 
 func (p *Plural) getClusterAttributes(registration *gqlclient.ClusterRegistrationFragment) (*gqlclient.ClusterAttributes, error) {

--- a/cmd/command/edge/edge.go
+++ b/cmd/command/edge/edge.go
@@ -121,6 +121,11 @@ func Commands(clients client.Plural, helmConfiguration *action.Configuration) []
 					Usage:    "the unique id of the edge device on which this cluster runs",
 					Required: true,
 				},
+				cli.StringFlag{
+					Name:     "chart-loc",
+					Usage:    "URL or filepath of helm chart tar file. Use if not wanting to install helm chart from default plural repository.",
+					Required: false,
+				},
 			},
 		},
 	}

--- a/pkg/client/plural.go
+++ b/pkg/client/plural.go
@@ -196,7 +196,7 @@ func (p *Plural) HandleInit(c *cli.Context) error {
 	return nil
 }
 
-func (p *Plural) DoInstallOperator(url, token, values string) error {
+func (p *Plural) DoInstallOperator(url, token, values, chart_loc string) error {
 	err := p.InitKube()
 	if err != nil {
 		return err
@@ -237,14 +237,14 @@ func (p *Plural) DoInstallOperator(url, token, values string) error {
 		}
 	}
 	vals = algorithms.Merge(vals, globalVals)
-	err = console.InstallAgent(url, token, console.OperatorNamespace, version, vals)
+	err = console.InstallAgent(url, token, console.OperatorNamespace, version, chart_loc, vals)
 	if err == nil {
 		utils.Success("deployment operator installed successfully\n")
 	}
 	return err
 }
 
-func (p *Plural) ReinstallOperator(c *cli.Context, id, handle *string) error {
+func (p *Plural) ReinstallOperator(c *cli.Context, id, handle *string, chart_loc string) error {
 	deployToken, err := p.ConsoleClient.GetDeployToken(id, handle)
 	if err != nil {
 		return err
@@ -257,5 +257,5 @@ func (p *Plural) ReinstallOperator(c *cli.Context, id, handle *string) error {
 		}
 	}
 
-	return p.DoInstallOperator(url, deployToken, c.String("values"))
+	return p.DoInstallOperator(url, deployToken, c.String("values"), chart_loc)
 }


### PR DESCRIPTION
## Summary
For `plural cd install` and `plural cd cluster bootstrap` allow user to pass in path to helm chart for operator (optional parameter, if not passed in by user just use default).

Main purpose of this is so that users can bootstrap their clusters in airgapped environments

https://linear.app/pluralsh/issue/PROD-3235/allow-customizing-helm-chart-url-in-plural-cd-install-and-plural-cd


## Test Plan
- Ran a kubernetes cluster locally on my macbook
- Created a local `.tgz` file for the helm chart
- Passed it in as param when running `plural cd cluster bootstrap`
- Verified that my local cluster shows up on my console

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.