### PR TITLE
fix(e2e): try to avoid dns caching for plural up retries

### DIFF
--- a/test/plural/up.yml
+++ b/test/plural/up.yml
@@ -108,6 +108,9 @@ testcases:
     steps:
       - script: |
           cd {{ .directory }} ;\
+          echo "nameserver 1.1.1.1" | tee /etc/resolv.conf.DNSoverride ;\
+          ln -sf /etc/resolv.conf.DNSoverride /etc/resolv.conf ;\
+          cat /etc/resolv.conf ;\
           plural up --commit "Plural up e2e cluster"
         retry: 3
         delay: 5


### PR DESCRIPTION
## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
This is an attempt to force `plural up` retries to not use DNS cache. Most of the time tests seem to be failing at console DNS resolve, and it is highly possible that it is due to the internal DNS cache. Since we are reusing the domain, it caches the old IP at the first attempt and never refreshes it.

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.