### PR TITLE
fix(e2e): use sudo for DNS override commands in e2e setup and fix askAppDomain

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,6 +12,7 @@ env:
   PLURAL_LOGIN_AFFIRM_CURRENT_USER: true
   PLURAL_UP_AFFIRM_DEPLOY: true
   PLURAL_DOWN_AFFIRM_DESTROY: true
+  PLURAL_UP_SKIP_APP_DOMAIN: true
   TESTOUT_PATH: /home/runner/testout
   SSH_PATH: /home/runner/.ssh
   VENOM_PATH: /usr/local/bin/venom

--- a/cmd/command/up/up.go
+++ b/cmd/command/up/up.go
@@ -178,12 +178,8 @@ func (p *Plural) choseCluster() (name, url string, err error) {
 }
 
 func askAppDomain() error {
-	project, err := manifest.FetchProject()
-	if err != nil {
-		return err
-	}
-
-	if len(project.AppDomain) > 0 {
+	skip, ok := utils.GetEnvBoolValue("PLURAL_UP_SKIP_APP_DOMAIN")
+	if ok && skip {
 		return nil
 	}
 
@@ -196,6 +192,10 @@ func askAppDomain() error {
 	}
 
 	if len(domain) > 0 {
+		project, err := manifest.FetchProject()
+		if err != nil {
+			return err
+		}
 		project.AppDomain = domain
 		return project.Flush()
 	}

--- a/cmd/command/up/up.go
+++ b/cmd/command/up/up.go
@@ -177,24 +177,30 @@ func (p *Plural) choseCluster() (name, url string, err error) {
 	return
 }
 
-func askAppDomain() (err error) {
-	var domain string
-	prompt := &survey.Input{
-		Message: "Enter the domain for your application.  It's expected that the root domain alreadys exist in your clouds DNS provider.  Leave empty to ignore",
-	}
-	if err = survey.AskOne(prompt, &domain); err != nil {
-		return
+func askAppDomain() error {
+	project, err := manifest.FetchProject()
+	if err != nil {
+		return err
 	}
 
-	if domain != "" {
-		project, err := manifest.FetchProject()
-		if err != nil {
-			return err
-		}
+	if len(project.AppDomain) > 0 {
+		return nil
+	}
+
+	var domain string
+	prompt := &survey.Input{
+		Message: "Enter the domain for your application.  It's expected that the root domain already exist in your clouds DNS provider.  Leave empty to ignore",
+	}
+	if err := survey.AskOne(prompt, &domain); err != nil {
+		return err
+	}
+
+	if len(domain) > 0 {
 		project.AppDomain = domain
 		return project.Flush()
 	}
-	return
+
+	return nil
 }
 
 func getCluster(cd *cdpkg.Plural) (id string, err error) {

--- a/test/plural/lib/workspace-setup.yml
+++ b/test/plural/lib/workspace-setup.yml
@@ -32,6 +32,7 @@ steps:
         project: {{ .input.project }}
         provider: {{ .input.provider }}
         region: {{ .input.region }}
+        appDomain: {{ .input.name }}.onplural.sh
         owner:
           email: {{ .input.email }}
         network:

--- a/test/plural/lib/workspace-setup.yml
+++ b/test/plural/lib/workspace-setup.yml
@@ -32,7 +32,6 @@ steps:
         project: {{ .input.project }}
         provider: {{ .input.provider }}
         region: {{ .input.region }}
-        appDomain: {{ .input.name }}.onplural.sh
         owner:
           email: {{ .input.email }}
         network:

--- a/test/plural/up.yml
+++ b/test/plural/up.yml
@@ -108,8 +108,8 @@ testcases:
     steps:
       - script: |
           cd {{ .directory }} ;\
-          echo "nameserver 1.1.1.1" | tee /etc/resolv.conf.DNSoverride ;\
-          ln -sf /etc/resolv.conf.DNSoverride /etc/resolv.conf ;\
+          echo "nameserver 1.1.1.1" | sudo tee /etc/resolv.conf.DNSoverride ;\
+          sudo ln -sf /etc/resolv.conf.DNSoverride /etc/resolv.conf ;\
           cat /etc/resolv.conf ;\
           plural up --commit "Plural up e2e cluster"
         retry: 3


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Fixed `askAppDomain` to allow running in non-interactive mode
- Run DNS setup command as sudo to avoid permissions issues
<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Manually dispatched e2e GH action

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.