### PR TITLE
allow http urls in plural up

### DIFF
--- a/pkg/up/context.go
+++ b/pkg/up/context.go
@@ -27,6 +27,8 @@ type Context struct {
 	Config           *config.Config
 	Cloud            bool
 	RepoUrl          string
+	GitUsername      string
+	GitPassword      string
 	StacksIdentity   string
 	Delims           *delims
 	ImportCluster    *string
@@ -43,6 +45,13 @@ type delims struct {
 func (ctx *Context) identifier() string {
 	if ctx.RepoUrl == "" {
 		return ""
+	}
+
+	if strings.HasPrefix(ctx.RepoUrl, "http") {
+		parsed, err := giturls.Parse(ctx.RepoUrl)
+		if err == nil {
+			return strings.TrimSuffix(strings.TrimPrefix(parsed.Path, "/"), ".git")
+		}
 	}
 
 	split := strings.Split(ctx.RepoUrl, ":")
@@ -72,13 +81,27 @@ func (ctx *Context) Backfill() error {
 		return ctx.backfillConsoleContext(ctx.Manifest)
 	}
 
-	if _, ok = console["private_key"]; !ok {
+	_, hasSSH := console["private_key"]
+	_, hasHTTPS := console["git_password"]
+	if !hasSSH && !hasHTTPS {
 		return ctx.backfillConsoleContext(ctx.Manifest)
 	}
 
 	if v, ok := console["repo_url"]; ok {
 		if r, ok := v.(string); ok {
 			ctx.RepoUrl = r
+		}
+	}
+
+	if v, ok := console["git_username"]; ok {
+		if s, ok := v.(string); ok {
+			ctx.GitUsername = s
+		}
+	}
+
+	if v, ok := console["git_password"]; ok {
+		if s, ok := v.(string); ok {
+			ctx.GitPassword = s
 		}
 	}
 
@@ -130,9 +153,13 @@ func (context *Context) backfillConsoleContext(_ *manifest.ProjectManifest) erro
 	}
 
 	if strings.HasPrefix(url, "http") {
-		return fmt.Errorf("found non-ssh upstream url %s, please reclone the repo with SSH and retry", url)
+		return context.backfillHTTPS(url, console, ctx, path)
 	}
 
+	return context.backfillSSH(url, console, ctx, path)
+}
+
+func (context *Context) backfillSSH(url string, console map[string]interface{}, ctx *manifest.Context, path string) error {
 	utils.Highlight("If you want, you can use `plural crypto ssh-keygen` to generate a keypair to use as a deploy key as well\n\n")
 
 	files, err := filepath.Glob(filepath.Join(os.Getenv("HOME"), ".ssh", "*"))
@@ -170,7 +197,41 @@ func (context *Context) backfillConsoleContext(_ *manifest.ProjectManifest) erro
 	console["repo_url"] = url
 	console["private_key"] = contents
 	ctx.Configuration["console"] = console
-	context.RepoUrl = url // ensure identifier() has the value for the current Generate() run
+	context.RepoUrl = url
+	return ctx.Write(path)
+}
+
+func (context *Context) backfillHTTPS(url string, console map[string]interface{}, ctx *manifest.Context, path string) error {
+	utils.Highlight("If you want, you can also reclone with an SSH URL and re-run to use deploy-key authentication instead\n\n")
+
+	var username, token string
+
+	if err := survey.AskOne(&survey.Input{
+		Message: "Enter your git username:",
+		Default: "oauth2",
+	}, &username, survey.WithValidator(survey.Required)); err != nil {
+		return err
+	}
+
+	if err := survey.AskOne(&survey.Password{
+		Message: "Enter your Personal Access Token (PAT) for this repository:",
+	}, &token, survey.WithValidator(survey.Required)); err != nil {
+		return err
+	}
+
+	if !context.ignorePreflights {
+		if err := verifyHTTPS(username, token, url); err != nil {
+			return fmt.Errorf("PAT not valid for url %s, error: %w.  If you want to bypass this check, you can use the --ignore-preflights flag", url, err)
+		}
+	}
+
+	console["repo_url"] = url
+	console["git_username"] = username
+	console["git_password"] = token
+	ctx.Configuration["console"] = console
+	context.RepoUrl = url
+	context.GitUsername = username
+	context.GitPassword = token
 	return ctx.Write(path)
 }
 
@@ -187,6 +248,22 @@ func verifySSHKey(key, url string) error {
 	}(dir)
 
 	auth, _ := git.SSHAuth(getGitUsername(url), key, "")
+	if _, err := git.Clone(auth, url, dir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyHTTPS(username, password, url string) error {
+	dir, err := os.MkdirTemp("", "repo")
+	if err != nil {
+		return err
+	}
+	defer func(path string) {
+		_ = os.RemoveAll(path)
+	}(dir)
+
+	auth, _ := git.BasicAuth(username, password)
 	if _, err := git.Clone(auth, url, dir); err != nil {
 		return err
 	}

--- a/pkg/up/context_test.go
+++ b/pkg/up/context_test.go
@@ -33,6 +33,22 @@ func TestGetGitUsername(t *testing.T) {
 			url:  "another-org@bitbucket.org:acme-workspace/mobile-app.git",
 			want: "another-org",
 		},
+		// HTTPS URLs – the embedded user from the URL should be returned
+		{
+			name: "github https with oauth2 user",
+			url:  "https://oauth2@github.com/acme-corp/widget-service.git",
+			want: "oauth2",
+		},
+		{
+			name: "github https without embedded user falls back to empty string",
+			url:  "https://github.com/acme-corp/widget-service.git",
+			want: "",
+		},
+		{
+			name: "gitlab https with x-token-auth user",
+			url:  "https://x-token-auth@gitlab.com/engineering/api-gateway.git",
+			want: "x-token-auth",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -42,3 +58,68 @@ func TestGetGitUsername(t *testing.T) {
 		})
 	}
 }
+
+func TestIdentifier(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoUrl string
+		want    string
+	}{
+		{
+			name:    "empty url",
+			repoUrl: "",
+			want:    "",
+		},
+		// HTTPS URLs
+		{
+			name:    "github https",
+			repoUrl: "https://github.com/acme-corp/widget-service.git",
+			want:    "acme-corp/widget-service",
+		},
+		{
+			name:    "github https without .git suffix",
+			repoUrl: "https://github.com/acme-corp/widget-service",
+			want:    "acme-corp/widget-service",
+		},
+		{
+			name:    "gitlab https nested group",
+			repoUrl: "https://gitlab.com/engineering/platform/api-gateway.git",
+			want:    "engineering/platform/api-gateway",
+		},
+		{
+			name:    "http (non-TLS) url",
+			repoUrl: "http://git.internal.example.com/myorg/myrepo.git",
+			want:    "myorg/myrepo",
+		},
+		{
+			name:    "github https with embedded credentials",
+			repoUrl: "https://oauth2:token@github.com/acme-corp/widget-service.git",
+			want:    "acme-corp/widget-service",
+		},
+		// SSH / SCP-style URLs
+		{
+			name:    "github scp-style",
+			repoUrl: "git@github.com:acme-corp/widget-service.git",
+			want:    "acme-corp/widget-service",
+		},
+		{
+			name:    "gitlab nested group scp-style",
+			repoUrl: "git@gitlab.com:engineering/platform/api-gateway.git",
+			want:    "engineering/platform/api-gateway",
+		},
+		{
+			name:    "scp without .git suffix",
+			repoUrl: "git@github.com:acme-corp/widget-service",
+			want:    "acme-corp/widget-service",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &Context{RepoUrl: tt.repoUrl}
+			if got := ctx.identifier(); got != tt.want {
+				t.Errorf("identifier() for url %q = %q, want %q", tt.repoUrl, got, tt.want)
+			}
+		})
+	}
+}
+

--- a/pkg/up/context_test.go
+++ b/pkg/up/context_test.go
@@ -122,4 +122,3 @@ func TestIdentifier(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/up/template.go
+++ b/pkg/up/template.go
@@ -81,6 +81,8 @@ func (ctx *Context) template(tmplate string) (string, error) {
 		"Cloud":          ctx.Cloud,
 		"ClusterName":    cluster,
 		"ProjectID":      ctx.Provider.Project(),
+		"GitUsername":    ctx.GitUsername,
+		"GitPassword":    ctx.GitPassword,
 	}
 	if ctx.Manifest.Network != nil {
 		values["Subdomain"] = ctx.Manifest.Network.Subdomain

--- a/pkg/wkspace/validator.go
+++ b/pkg/wkspace/validator.go
@@ -26,16 +26,6 @@ func Preflight(dryRun, ignorePreflights bool) (bool, error) {
 	}
 	fmt.Print("All required CLI dependencies are present.\n\n")
 
-	if !dryRun && !ignorePreflights {
-		fmt.Print("\nTesting if git ssh is properly configured...")
-		if err := checkGitSSH(); err != nil {
-			fmt.Printf("%s\n\n", err.Error())
-			utils.Warn("Please ensure that you have ssh keys set up for git and that you've added them to your ssh agent. You can use `plural crypto ssh-keygen` to create your first ssh keys then upload the public key to your git provider.\n")
-			return true, fmt.Errorf("git ssh is not properly configured")
-		}
-		fmt.Printf(" \033[32m (\u2713) \033[0m\n\n")
-	}
-
 	fmt.Print("Checking git repository setup...\n")
 	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
 	if _, err := cmd.CombinedOutput(); err != nil {
@@ -57,11 +47,16 @@ func Preflight(dryRun, ignorePreflights bool) (bool, error) {
 		return true, err
 	}
 
-	if strings.HasPrefix(url, "http") && !dryRun {
-		utils.Error("Found non-ssh upstream url %s, please reclone the repo with SSH and retry.\n", url)
-		utils.Warn("Please ensure that you have SSH keys set up for Git and that you've added them to your SSH agent.\n")
-		utils.Warn("You can use `plural crypto ssh-keygen` to create your first SSH keys then upload the public key to your Git provider.\n")
-		return true, fmt.Errorf("found non-ssh upstream")
+	isHTTPS := strings.HasPrefix(url, "http")
+
+	if !dryRun && !ignorePreflights && !isHTTPS {
+		fmt.Print("\nTesting if git ssh is properly configured...")
+		if err := checkGitSSH(); err != nil {
+			fmt.Printf("%s\n\n", err.Error())
+			utils.Warn("Please ensure that you have ssh keys set up for git and that you've added them to your ssh agent. You can use `plural crypto ssh-keygen` to create your first ssh keys then upload the public key to your git provider.\n")
+			return true, fmt.Errorf("git ssh is not properly configured")
+		}
+		fmt.Printf(" \033[32m (\u2713) \033[0m\n\n") // (✓)
 	}
 
 	return true, nil


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
Allow HTTPS git URLs in `plural up`
Previously `plural up` only worked with SSH git remotes. This PR adds full HTTPS/PAT support.

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.