### PR TITLE
Fix: Skip DNS setup if no zones exist in Azure resource group

### DIFF
--- a/cmd/command/up/up.go
+++ b/cmd/command/up/up.go
@@ -278,6 +278,11 @@ func askAppDomain(project *manifest.ProjectManifest) error {
 			break
 		}
 
+		// Skip domain setup if no DNS zones exist in the resource group.
+		if len(dnsZones) == 0 {
+			break
+		}
+
 		if err := survey.AskOne(
 			&survey.Select{Message: "Select DNS zone (leave as None to skip):", Options: append([]string{noneOption}, dnsZones...)},
 			&domain,

--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -484,6 +484,15 @@ func AzureDNSZones(ctx context.Context, resourceGroup string) ([]string, error) 
 		return nil, err
 	}
 
+	// If the resource group doesn't exist yet, there are no DNS zones to list.
+	_, err = clients.Groups.Get(ctx, resourceGroup, nil)
+	if err != nil {
+		if isNotFoundResourceGroup(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
 	var zones []string
 	pager := clients.Zones.NewListByResourceGroupPager(resourceGroup, nil)
 	for pager.More() {


### PR DESCRIPTION
## Summary
When running plural up with a new resource group, fetching DNS zones failed with a 404 because the group didn't exist yet (it's created later in the process). `AzureDNSZones` now returns an empty list instead of an error in this case, and `askAppDomain` silently skips the DNS zone prompt when there are no zones.

## Test Plan
```
...

? Enter the name of your cluster: <redacted>
? Select the location you want to deploy to: polandcentral
? Select the resource group to use: Create new...
? Enter resource group name: <redacted>
? Select the storage account to use: Create new...
? Enter globally unique storage account name: <redacted>
? Enter a unique, memorable string to use for bucket naming, e.g. an abbreviation for your company: <redacted>
? Enter subdomain of onplural.sh domain that you want to use: <redacted>
? You're attempting to setup plural outside a git repository. Would you like us to set one up for you here? Yes
? Select the SCM provider to use for your repository: github

...

Finished setting up your management cluster!
Feel free to use terraform as you normally would, and leverage the gitops setup we've generated in the bootstrap/ subfolder

Process finished with the exit code 0
```

## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.