### PR TITLE
fix: pin alpine openssl packages in CLI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM golang:1.26.4-alpine3.22 AS final
 
 WORKDIR /
 
-RUN apk update && apk add --no-cache git build-base
+RUN apk update && apk add --no-cache git build-base libssl3=3.5.7-r0 libcrypto3=3.5.7-r0
 
 # Copy nonroot user and switch to it
 COPY --from=user /etc/passwd /etc/passwd


### PR DESCRIPTION
## Summary
- pin `libssl3` and `libcrypto3` in the final CLI image stage to `3.5.7-r0`
- keep the remediation scoped to the confirmed remediable image-package alerts
- document why the reported Go stdlib and transitive `oras.land/oras-go/v2` alerts were not changed here

## Why this is safe
- the repository already uses `golang:1.26.4-alpine3.22`; this change only constrains the installed Alpine OpenSSL packages in that existing image family
- `apk policy` for Alpine 3.22 resolves both packages to `3.5.7-r0`, matching the fixed version identified during discovery

## Reported alerts covered
- `libssl3` image-package alert: pinned to `3.5.7-r0`
- `libcrypto3` image-package alert: pinned to `3.5.7-r0`

## Remaining reported findings and blockers
- Go stdlib / toolchain findings (`CVE-2024-45341`, `CVE-2024-45336`): the repo already declares `go 1.26.4` in `go.mod`, which is newer than the discovery-noted fixed `1.23.5+` / `1.23.6+` ranges, so no remediation edit was needed
- `oras.land/oras-go/v2` / `GHSA-fxhp-mv3v-67qp`: the dependency is transitive via `helm.sh/helm/v3 v3.21.2`. Inspecting the downloaded Helm module confirmed Helm 3.21.2 still requires `oras.land/oras-go/v2 v2.6.1`. I could not verify a minimal newer Helm version carrying a patched ORAS version from the module proxy in this environment, so I did not guess at a parent or override update

## Files changed
- `Dockerfile` — pin `libssl3` and `libcrypto3` in the final image stage

## Validation
- `docker run --rm alpine:3.22 sh -lc "apk update >/dev/null && apk policy libssl3 libcrypto3"`
- `docker build --target final -t plural-cli-security-check .`

## Existing PRs considered
- I attempted to list open PRs for `pluralsh/plural-cli` through the GitHub API from this environment, but the unauthenticated response body was empty, so I could not confirm any existing broad remediation PR covering all reported alerts

## Labels
- `dependencies`